### PR TITLE
feat(payment): payment-service 초기 스캐폴딩 및 기본 실행 구성

### DIFF
--- a/services/payment-service/build.gradle
+++ b/services/payment-service/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.paystream'
+version = '0.0.1-SNAPSHOT'
+description = 'Payment Service'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
+dependencies {
+    // Spring Boot Starters
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // Spring Cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    
+    // Development
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
@@ -1,0 +1,12 @@
+package com.paystream.payment;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}

--- a/services/payment-service/src/main/java/com/paystream/payment/controller/PaymentController.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/controller/PaymentController.java
@@ -1,0 +1,23 @@
+package com.paystream.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/payments")
+public class PaymentController {
+
+    @GetMapping("/ping")
+    public ResponseEntity<Map<String, Object>> ping() {
+        return ResponseEntity.ok(Map.of(
+            "service", "payment-service",
+            "status", "UP",
+            "timestamp", LocalDateTime.now()
+        ));
+    }
+}

--- a/services/payment-service/src/main/resources/application-dev.yml
+++ b/services/payment-service/src/main/resources/application-dev.yml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8083
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server:8761/eureka/
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.value}
+
+logging:
+  level:
+    com.paystream.payment: INFO
+    org.springframework.cloud: INFO

--- a/services/payment-service/src/main/resources/application-dev.yml
+++ b/services/payment-service/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: dev
 
 server:
-  port: 8083
+  port: 8084
 
 eureka:
   client:
@@ -18,3 +18,4 @@ logging:
   level:
     com.paystream.payment: INFO
     org.springframework.cloud: INFO
+

--- a/services/payment-service/src/main/resources/application-local.yml
+++ b/services/payment-service/src/main/resources/application-local.yml
@@ -1,0 +1,21 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+server:
+  port: 8083
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.value}
+
+logging:
+  level:
+    com.paystream.payment: DEBUG
+    org.springframework.cloud: DEBUG
+    org.springframework.web: DEBUG

--- a/services/payment-service/src/main/resources/application-local.yml
+++ b/services/payment-service/src/main/resources/application-local.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
 
 server:
-  port: 8083
+  port: 8084
 
 eureka:
   client:

--- a/services/payment-service/src/main/resources/application.yml
+++ b/services/payment-service/src/main/resources/application.yml
@@ -24,7 +24,7 @@ eureka:
     fetch-registry: true
   instance:
     prefer-ip-address: true
-    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+    instance-id: ${spring.application.name}:${random.value}
 
 logging:
   level:

--- a/services/payment-service/src/main/resources/application.yml
+++ b/services/payment-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     active: local
 
 server:
-  port: 8083
+  port: 8084
 
 management:
   endpoints:

--- a/services/payment-service/src/main/resources/application.yml
+++ b/services/payment-service/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+spring:
+  application:
+    name: payment-service
+  profiles:
+    active: local
+
+server:
+  port: 8083
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: when-authorized
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+logging:
+  level:
+    com.paystream.payment: DEBUG
+    org.springframework.cloud: DEBUG

--- a/services/payment-service/src/test/java/com/paystream/payment/PaymentServiceApplicationTests.java
+++ b/services/payment-service/src/test/java/com/paystream/payment/PaymentServiceApplicationTests.java
@@ -1,0 +1,19 @@
+package com.paystream.payment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "eureka.client.enabled=false",
+    "eureka.client.register-with-eureka=false",
+    "eureka.client.fetch-registry=false"
+})
+class PaymentServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // 애플리케이션 컨텍스트가 정상적으로 로드되는지 확인
+    }
+}

--- a/services/payment-service/src/test/java/com/paystream/payment/controller/PaymentControllerTest.java
+++ b/services/payment-service/src/test/java/com/paystream/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,29 @@
+package com.paystream.payment.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(PaymentController.class)
+@TestPropertySource(properties = {
+    "eureka.client.enabled=false",
+    "eureka.client.register-with-eureka=false",
+    "eureka.client.fetch-registry=false"
+})
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void ping_shouldReturnOk() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/payments/ping"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.service").value("payment-service"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("UP"));
+    }
+}

--- a/services/payment-service/src/test/resources/application-test.yml
+++ b/services/payment-service/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: payment-service-test
+  profiles:
+    active: test
+
+server:
+  port: 0  # 랜덤 포트 사용
+
+eureka:
+  client:
+    enabled: false  # 테스트 시 Eureka 비활성화
+    register-with-eureka: false
+    fetch-registry: false
+
+logging:
+  level:
+    com.paystream.payment: DEBUG

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,4 @@ rootProject.name = 'PayStream'
 include ':services:api-gateway'
 include ':services:eureka-server'
 include ':services:inventory-service'
-
+include ':services:payment-service'


### PR DESCRIPTION
### 📌 PR 개요
- payment-service 모듈 초기 스캐폴딩 및 기본 실행/디스커버리/헬스체크 구동 확립

### 🔍 변경 사항
- settings.gradle: `:services:payment-service` 모듈 포함
- services/payment-service/build.gradle: Spring Boot 3.5.6 / Spring Cloud 2025.0.0 정합, 필수 의존성 구성
- Application 코드
  - `PaymentServiceApplication` 부팅 클래스 추가
  - `PaymentController`에 `/payments/ping` 엔드포인트 추가(스모크용)
- 설정 파일(멀티 프로필)
  - `application.yml`(공통) + `application-local.yml` + `application-dev.yml`
  - Actuator health/info 노출, Eureka 클라이언트 등록 설정
- 테스트
  - `PaymentServiceApplicationTests`: 컨텍스트 로드
  - `PaymentControllerTest`: `/payments/ping` WebMvcTest
  - `application-test.yml`: 테스트 프로필용 설정(Eureka 비활성화)

### 🧪 테스트 방법
1. Eureka 서버 실행
   - `./gradlew :services:eureka-server:bootRun`
   - 대시보드 접속: `http://localhost:8761`
2. Payment Service 실행
   - `./gradlew :services:payment-service:bootRun` (기본 `local` 프로필)
3. 헬스/핑 확인
   - `curl http://localhost:8084/actuator/health` → `{"status":"UP"}`
   - `curl http://localhost:8084/payments/ping` → 200 OK(JSON)
4. Eureka 등록 확인
   - 대시보드에서 `PAYMENT-SERVICE` 인스턴스 `UP` 상태 확인
5. 테스트 실행
   - `./gradlew :services:payment-service:test` → 모든 테스트 통과

### ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
-

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #1 