### PR TITLE
feat: notification-service 초기 세팅

### DIFF
--- a/services/notification-service/build.gradle
+++ b/services/notification-service/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.paystream'
+version = '0.0.1-SNAPSHOT'
+description = 'NotificationService'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
+dependencies {
+    // Spring Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    
+    // Eureka Client - 서비스 디스커버리 등록
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    
+    // Actuator - 헬스 체크 및 모니터링
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // Kafka - 이벤트 기반 알림 수신 (추후 활성화)
+    // implementation 'org.springframework.kafka:spring-kafka'
+    
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    
+    // DevTools - 개발 편의성
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}
+

--- a/services/notification-service/src/main/java/com/paystream/notification/NotificationServiceApplication.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/NotificationServiceApplication.java
@@ -1,0 +1,21 @@
+package com.paystream.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+/**
+ * 알림 서비스 메인 애플리케이션
+ * - Eureka Client로 등록되어 서비스 디스커버리 활용
+ * - Kafka 이벤트 기반 알림 처리 (추후 구현)
+ */
+@EnableDiscoveryClient
+@SpringBootApplication
+public class NotificationServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+
+}
+

--- a/services/notification-service/src/main/java/com/paystream/notification/controller/HealthController.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/controller/HealthController.java
@@ -1,0 +1,53 @@
+package com.paystream.notification.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 헬스 체크 컨트롤러
+ * - 서비스 정상 동작 확인용 엔드포인트 제공
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/notifications")
+public class HealthController {
+
+    /**
+     * 서비스 헬스 체크 엔드포인트
+     * @return 서비스 상태 정보
+     */
+    @GetMapping("/ping")
+    public ResponseEntity<Map<String, Object>> ping() {
+        log.info("헬스 체크 요청 수신");
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("service", "notification-service");
+        response.put("status", "UP");
+        response.put("timestamp", LocalDateTime.now());
+        response.put("message", "알림 서비스가 정상 작동 중입니다.");
+        
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 서비스 정보 조회 엔드포인트
+     * @return 서비스 기본 정보
+     */
+    @GetMapping("/info")
+    public ResponseEntity<Map<String, String>> info() {
+        Map<String, String> info = new HashMap<>();
+        info.put("name", "PayStream Notification Service");
+        info.put("version", "0.0.1-SNAPSHOT");
+        info.put("description", "이벤트 기반 알림 처리 서비스");
+        
+        return ResponseEntity.ok(info);
+    }
+}
+

--- a/services/notification-service/src/main/resources/application.yml
+++ b/services/notification-service/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: notification-service
+
+# Eureka Client 설정
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/ # Eureka Server 주소
+    register-with-eureka: true # Eureka에 서비스 등록
+    fetch-registry: true # 다른 서비스 정보 가져오기
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+    prefer-ip-address: true # IP 주소 우선 사용
+
+# Actuator 설정 - 헬스 체크 및 모니터링
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics # 노출할 엔드포인트
+  endpoint:
+    health:
+      show-details: always # 헬스 상세 정보 표시
+
+# 로그 레벨 설정
+logging:
+  level:
+    com.paystream.notification: INFO
+    org.springframework.cloud: DEBUG

--- a/services/notification-service/src/test/java/com/paystream/notification/NotificationServiceApplicationTests.java
+++ b/services/notification-service/src/test/java/com/paystream/notification/NotificationServiceApplicationTests.java
@@ -1,0 +1,22 @@
+package com.paystream.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * NotificationService 애플리케이션 통합 테스트
+ */
+@SpringBootTest
+class NotificationServiceApplicationTests {
+
+    /**
+     * 스프링 컨텍스트 로딩 테스트
+     * - 애플리케이션이 정상적으로 기동되는지 확인
+     */
+    @Test
+    void contextLoads() {
+        // 컨텍스트가 정상적으로 로드되면 테스트 통과
+    }
+
+}
+

--- a/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
+++ b/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
@@ -1,0 +1,42 @@
+package com.paystream.notification.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * HealthController 단위 테스트
+ */
+@WebMvcTest(HealthController.class)
+class HealthControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("ping 엔드포인트 - 정상 응답 확인")
+    void testPingEndpoint() throws Exception {
+        mockMvc.perform(get("/api/notifications/ping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.service").value("notification-service"))
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("info 엔드포인트 - 서비스 정보 조회")
+    void testInfoEndpoint() throws Exception {
+        mockMvc.perform(get("/api/notifications/info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("PayStream Notification Service"))
+                .andExpect(jsonPath("$.version").value("0.0.1-SNAPSHOT"))
+                .andExpect(jsonPath("$.description").exists());
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,9 @@
 rootProject.name = 'PayStream'
 
+include ':common:core'
+
 include ':services:api-gateway'
 include ':services:eureka-server'
 include ':services:inventory-service'
+include ':services:payment-service'
 include ':services:notification-service'
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ rootProject.name = 'PayStream'
 include ':services:api-gateway'
 include ':services:eureka-server'
 include ':services:inventory-service'
+include ':services:notification-service'
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- notification-service 초기 세팅 및 기본 구조 구현 - 알림 서비스의 기반이 되는 프로젝트 구조와 핵심 컴포넌트 추가

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- settings.gradle에 notification-service 모듈 추가
- build.gradle 작성 (Java 17, Spring Boot 3.5.6, Spring Cloud 2025.0.0)
- NotificationServiceApplication 메인 클래스 생성 (@EnableDiscoveryClient)
- application.yml 설정 (포트 8083, Eureka 연결)
- Actuator 설정 (health, info, metrics 엔드포인트)
- HealthController 구현 (/api/notifications/ping, /api/notifications/info)
- 통합 테스트 및 단위 테스트 작성
- Lombok, DevTools 의존성 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. Eureka Server 먼저 실행: ./gradlew :services:eureka-server:bootRun
2. Notification Service 실행: ./gradlew :services:notification-service:bootRun
3. 헬스체크 확인: curl http://localhost:8083/api/notifications/ping
4. Eureka 대시보드에서 서비스 등록 확인: http://localhost:8761
5. Actuator 엔드포인트 확인: curl http://localhost:8083/actuator/health

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 필요 시 문서 업데이트 완료
- [  ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- 추후 Kafka 이벤트 기반 알림 처리, FCM 푸시 알림, 이메일 알림 등 확장 예정입니다.
- 포트 8083 사용 (eureka-server: 8761과 충돌 방지)

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #