### PR TITLE
feat(order): order-service 초기 스캐폴딩 및 기본 실행 구성

### DIFF
--- a/services/order-service/build.gradle
+++ b/services/order-service/build.gradle
@@ -1,0 +1,64 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.paystream'
+version = '0.0.1-SNAPSHOT'
+description = 'Order Service'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    springCloudVersion = "2025.0.0"   // Spring Boot 3.5.x와 호환
+}
+
+dependencies {
+    // spring boot starter
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // spring cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Development
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // JPA + H2 (로컬)
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/services/order-service/src/main/java/com/paystream/order/OrderServiceApplication.java
+++ b/services/order-service/src/main/java/com/paystream/order/OrderServiceApplication.java
@@ -1,0 +1,11 @@
+package com.paystream.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OrderServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OrderServiceApplication.class, args);
+    }
+}

--- a/services/order-service/src/main/java/com/paystream/order/controller/PingController.java
+++ b/services/order-service/src/main/java/com/paystream/order/controller/PingController.java
@@ -1,0 +1,25 @@
+package com.paystream.order.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/orders")
+public class PingController {
+
+    @GetMapping("/ping")
+    public ResponseEntity<Map<String, Object>> ping() {
+        return ResponseEntity.ok(
+                Map.of(
+                        "service", "order-service",
+                        "status", "UP",
+                        "timestamp", LocalDateTime.now().toString()
+                )
+        );
+    }
+}

--- a/services/order-service/src/main/resources/application-local.yml
+++ b/services/order-service/src/main/resources/application-local.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:userdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    root: INFO
+    com.paystream.user: DEBUG
+    org.springframework.cloud: DEBUG
+    org.springframework.web: DEBUG

--- a/services/order-service/src/main/resources/application.yml
+++ b/services/order-service/src/main/resources/application.yml
@@ -1,0 +1,32 @@
+server:
+  port: 8083   # order-service 포트
+
+spring:
+  application:
+    name: order-service
+  profiles:
+    active: local   # 기본 실행 프로필 (application-local.yml 불러옴)
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${random.value}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: when-authorized
+
+logging:
+  level:
+    com.paystream.user: DEBUG
+    org.springframework.cloud: DEBUG

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,4 @@ include ':services:inventory-service'
 include ':services:payment-service'
 include ':services:notification-service'
 include ':services:user-service'
-
+include ':services:order-service'


### PR DESCRIPTION
## 📌 PR 개요
- `order-service` 모듈을 신규 생성하고 최소 실행 가능한 스캐폴딩을 구성
- Eureka 등록, Actuator 헬스체크, 기본 ping API까지 확인

## 🔍 변경 사항
- `settings.gradle`에 `:services:order-service` 등록
- `services/order-service/build.gradle` 추가 (Boot 3.5.x / Java 17 / Spring Cloud 2025.0.x / web, validation, actuator, eureka, lombok, test)
- `application.yml` (공통) 작성: `server.port=8086`, `spring.application.name=order-service`, Eureka/Actuator 설정
- `application-local.yml` (로컬) 작성: H2/JPA/로그 레벨 초안
- `OrderServiceApplication` 생성
- `PingController` 생성: `@RequestMapping("/api/orders")`, `GET /ping` → 200 OK

## 🧪 테스트 방법
1. **Eureka 서버 실행**
   - 브라우저에서 `http://localhost:8761` 접속 → 대시보드 확인
2. **order-service 실행**
   - `./gradlew :services:order-service:bootRun`
3. **헬스체크**
   - `curl http://localhost:8083/actuator/health` → `{"status":"UP"}`
   - 
<img width="898" height="142" alt="헬스체크_order" src="https://github.com/user-attachments/assets/734a7123-9516-4beb-a830-4499a3bb05ce" />

4. **핑 API**
   - `curl http://localhost:8083/api/orders/ping` → 200 OK(JSON 응답)
   - 
<img width="898" height="174" alt="Ping API 확인_order" src="https://github.com/user-attachments/assets/3982f16f-088c-4397-8fbf-a8ad199d241a" />

5. **Eureka 등록 확인**
   - 대시보드에서 `ORDER-SERVICE`가 **UP** 상태로 표시됨
   - 
<img width="1884" height="2000" alt="Eureka Server 실행_order " src="https://github.com/user-attachments/assets/a6d1c819-883b-45e8-812e-bd46161c47c3" />

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항
- 포트: `8083`
- H2/JPA 설정은 로컬 프로필에 한정되어 있습니다.

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #13 