### PR TITLE
fix(dev-scripts): install-hooks 스크립트에서 .git/hooks 디렉토리 자동 생성

### DIFF
--- a/dev-scripts/install-hooks.sh
+++ b/dev-scripts/install-hooks.sh
@@ -19,8 +19,8 @@ if [ ! -d "$GITHOOKS_DIR" ]; then
 fi
 
 if [ ! -d "$GIT_HOOKS_DIR" ]; then
-    echo "😈 오류: .git/hooks 디렉토리를 찾을 수 없습니다. Git 저장소인지 확인해주세요."
-    exit 1
+    echo "⚠️  .git/hooks 디렉토리가 없어서 생성합니다..."
+    mkdir -p "$GIT_HOOKS_DIR"
 fi
 
 # githooks/의 모든 hooks를 .git/hooks/로 복사


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Git hooks 설치 스크립트에서 `.git/hooks` 디렉토리가 없을 때 오류가 발생하는 문제를 수정하여, 디렉토리가 없으면 자동으로 생성하도록 개선.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `install-hooks.sh` 스크립트에서 `.git/hooks` 디렉토리 존재 여부 확인 로직 수정
- 디렉토리가 없을 때 오류를 발생시키는 대신 `mkdir -p`로 자동 생성하도록 변경
- 사용자에게 디렉토리 생성 안내 메시지 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. `.git/hooks` 디렉토리를 삭제 (또는 없는 상태에서)
2. `./dev-scripts/install-hooks.sh` 실행
3. 디렉토리가 자동으로 생성되고 hooks가 정상적으로 설치되는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- Git 저장소에서 `.git/hooks` 디렉토리가 없는 경우에도 스크립트가 정상 동작
- 스크립트 실행 시 디렉토리가 자동으로 생성되므로 별도의 수동 작업이 필요 없음

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #