### PR TITLE
feat(user-service): 회원가입, 로그인 및 리프레시 토큰 기능 구현 #26 #27

### DIFF
--- a/services/user-service/src/main/java/com/paystream/user/config/JwtConfig.java
+++ b/services/user-service/src/main/java/com/paystream/user/config/JwtConfig.java
@@ -1,0 +1,8 @@
+package com.paystream.user.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+    // JWT 설정은 application.yml에서 관리
+}

--- a/services/user-service/src/main/java/com/paystream/user/config/SecurityConfig.java
+++ b/services/user-service/src/main/java/com/paystream/user/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.paystream.user.config;
+
+import com.paystream.user.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .sessionManagement(
+                        session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(
+                        jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers(
+                                                "/users/ping",
+                                                "/users/signup",
+                                                "/users/login",
+                                                "/users/refresh",
+                                                "/users/logout",
+                                                "/swagger-ui/**",
+                                                "/v3/api-docs/**",
+                                                "/swagger-ui.html")
+                                        .permitAll()
+                                        .anyRequest()
+                                        .authenticated());
+
+        return http.build();
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/controller/AuthController.java
+++ b/services/user-service/src/main/java/com/paystream/user/controller/AuthController.java
@@ -1,0 +1,55 @@
+package com.paystream.user.controller;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.paystream.core.BaseResponse;
+import com.paystream.user.dto.request.LoginRequest;
+import com.paystream.user.dto.request.RefreshTokenRequest;
+import com.paystream.user.dto.request.SignupRequest;
+import com.paystream.user.dto.response.TokenResponse;
+import com.paystream.user.service.AuthService;
+import com.paystream.user.service.UserCreateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class AuthController {
+
+    private final AuthService authService;
+    private final UserCreateService userCreateService;
+
+    @PostMapping("/signup")
+    public BaseResponse<Long> signup(@Valid @RequestBody SignupRequest request) {
+        Long id = userCreateService.create(request);
+        return BaseResponse.created(id);
+    }
+
+    @PostMapping("/login")
+    public BaseResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(request);
+        return BaseResponse.ok(tokenResponse);
+    }
+
+    @PostMapping("/refresh")
+    public BaseResponse<TokenResponse> refreshToken(
+            @Valid @RequestBody RefreshTokenRequest request) {
+        TokenResponse tokenResponse = authService.refreshToken(request);
+        return BaseResponse.ok(tokenResponse);
+    }
+
+    @PostMapping("/logout")
+    public BaseResponse<String> logout(
+            @RequestHeader(value = AUTHORIZATION, required = false) String authorization) {
+        // Authorization 헤더에서 Bearer 토큰 추출
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("Authorization 헤더에 Bearer 토큰이 필요합니다.");
+        }
+
+        String accessToken = authorization.substring(7); // "Bearer " 제거
+        authService.logout(accessToken);
+        return BaseResponse.ok("로그아웃되었습니다.");
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/request/LoginRequest.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/request/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.paystream.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/request/RefreshTokenRequest.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,17 @@
+package com.paystream.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "리프레시 토큰은 필수 입력 항목입니다.")
+    private String refreshToken;
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/request/SignupRequest.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/request/SignupRequest.java
@@ -1,0 +1,51 @@
+package com.paystream.user.dto.request;
+
+import com.paystream.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    private String name;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+
+    private String phone;
+
+    @jakarta.validation.constraints.NotNull(message = "필수 약관에 동의해야 합니다.")
+    private Boolean termsOfServiceAgreed;
+
+    @jakarta.validation.constraints.NotNull(message = "필수 약관에 동의해야 합니다.")
+    private Boolean privacyPolicyAgreed;
+
+    private Boolean marketingAgreed;
+
+    public User toEntity(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .password(passwordEncoder.encode(password))
+                .phone(phone)
+                .termsOfServiceAgreed(termsOfServiceAgreed)
+                .privacyPolicyAgreed(privacyPolicyAgreed)
+                .marketingAgreed(marketingAgreed != null ? marketingAgreed : false)
+                .termsAgreedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/response/TokenResponse.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/response/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.paystream.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder.Default private String tokenType = "Bearer";
+
+    private Long expiresIn; // 액세스 토큰 만료 시간 (초)
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/AuthService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/AuthService.java
@@ -1,0 +1,133 @@
+package com.paystream.user.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.user.dto.request.LoginRequest;
+import com.paystream.user.dto.request.RefreshTokenRequest;
+import com.paystream.user.dto.request.SignupRequest;
+import com.paystream.user.dto.response.TokenResponse;
+import com.paystream.user.entity.User;
+import com.paystream.user.repository.UserRepository;
+import com.paystream.user.util.JwtUtil;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final TokenBlacklistService tokenBlacklistService;
+
+    @Transactional
+    public Long signup(SignupRequest request) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new PayStreamException(ExceptionEnum.USER_ALREADY_EXISTS);
+        }
+
+        User user = request.toEntity(passwordEncoder);
+        return userRepository.save(user).getId();
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        User user =
+                userRepository
+                        .findByEmail(request.getEmail())
+                        .orElseThrow(
+                                () -> new PayStreamException(ExceptionEnum.INVALID_CREDENTIALS));
+
+        // 비밀번호 확인
+        if (user.getPassword() == null
+                || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new PayStreamException(ExceptionEnum.INVALID_CREDENTIALS);
+        }
+
+        // 이메일 인증 확인 (나중에 이메일 인증 기능 추가 시 활성화)
+        // if (!user.getEmailVerified()) {
+        //     throw new PayStreamException(ExceptionEnum.EMAIL_NOT_VERIFIED);
+        // }
+
+        // JWT 토큰 생성
+        String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId(), user.getEmail());
+
+        // 리프레시 토큰 저장
+        LocalDateTime refreshTokenExpiry =
+                LocalDateTime.now().plusSeconds(jwtUtil.getRefreshTokenExpiration() / 1000);
+        user.updateRefreshToken(refreshToken, refreshTokenExpiry);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(jwtUtil.getAccessTokenExpiration() / 1000)
+                .build();
+    }
+
+    @Transactional
+    public TokenResponse refreshToken(RefreshTokenRequest request) {
+        // 리프레시 토큰 검증
+        if (!jwtUtil.validateToken(request.getRefreshToken(), "refresh")) {
+            throw new PayStreamException(ExceptionEnum.INVALID_REFRESH_TOKEN);
+        }
+
+        Long userId = jwtUtil.extractUserId(request.getRefreshToken());
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        // 저장된 리프레시 토큰과 일치하는지 확인
+        if (!user.getRefreshToken().equals(request.getRefreshToken())) {
+            throw new PayStreamException(ExceptionEnum.INVALID_REFRESH_TOKEN);
+        }
+
+        // 리프레시 토큰 만료 확인
+        if (user.getRefreshTokenExpiryDate() == null
+                || user.getRefreshTokenExpiryDate().isBefore(LocalDateTime.now())) {
+            throw new PayStreamException(ExceptionEnum.EXPIRED_REFRESH_TOKEN);
+        }
+
+        // 새로운 토큰 생성
+        String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getId(), user.getEmail());
+
+        // 리프레시 토큰 업데이트
+        LocalDateTime refreshTokenExpiry =
+                LocalDateTime.now().plusSeconds(jwtUtil.getRefreshTokenExpiration() / 1000);
+        user.updateRefreshToken(refreshToken, refreshTokenExpiry);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(jwtUtil.getAccessTokenExpiration() / 1000)
+                .build();
+    }
+
+    @Transactional
+    public void logout(String accessToken) {
+        // 액세스 토큰 검증
+        if (!jwtUtil.validateToken(accessToken, "access")) {
+            throw new PayStreamException(ExceptionEnum.INVALID_CREDENTIALS);
+        }
+
+        // 액세스 토큰에서 사용자 ID 추출
+        Long userId = jwtUtil.extractUserId(accessToken);
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        // 액세스 토큰을 블랙리스트에 추가 (즉시 로그아웃)
+        tokenBlacklistService.addToBlacklist(accessToken);
+
+        // 리프레시 토큰 삭제 (새로운 토큰 발급 방지)
+        user.clearRefreshToken();
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/UserCreateService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/UserCreateService.java
@@ -1,0 +1,30 @@
+package com.paystream.user.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.user.dto.request.SignupRequest;
+import com.paystream.user.entity.User;
+import com.paystream.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCreateService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Long create(SignupRequest request) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new PayStreamException(ExceptionEnum.USER_ALREADY_EXISTS);
+        }
+
+        User user = request.toEntity(passwordEncoder);
+        return userRepository.save(user).getId();
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/util/JwtUtil.java
+++ b/services/user-service/src/main/java/com/paystream/user/util/JwtUtil.java
@@ -1,0 +1,105 @@
+package com.paystream.user.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret:PayStreamSecretKeyForJWTTokenGenerationAndValidation123456789}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration:3600000}") // 기본 1시간
+    private Long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration:604800000}") // 기본 7일
+    private Long refreshTokenExpiration;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId, String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("type", "access")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId, String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("type", "refresh")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public Long extractUserId(String token) {
+        Claims claims = extractClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public String extractEmail(String token) {
+        Claims claims = extractClaims(token);
+        return claims.get("email", String.class);
+    }
+
+    public String extractTokenType(String token) {
+        Claims claims = extractClaims(token);
+        return claims.get("type", String.class);
+    }
+
+    public boolean isTokenExpired(String token) {
+        try {
+            Claims claims = extractClaims(token);
+            return claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    public boolean validateToken(String token, String expectedType) {
+        try {
+            Claims claims = extractClaims(token);
+            String type = claims.get("type", String.class);
+            return type != null && type.equals(expectedType) && !isTokenExpired(token);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
+    public Long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
user-service에 회원가입, 로그인 및 JWT 리프레시 토큰 기능 구현. JWT 기반 인증 시스템을 구축하여 사용자 인증 및 토큰 관리 기능 제공.
- 회원가입 API 구현 (이메일 중복 검증 포함)
- 로그인 API 구현 (JWT Access Token 및 Refresh Token 발급)
- 리프레시 토큰을 통한 Access Token 갱신 기능

## 🔍 변경 사항

### DTO
- SignupRequest: 회원가입 요청 DTO (이메일, 이름, 비밀번호, 전화번호, 약관 동의)
- LoginRequest: 로그인 요청 DTO (이메일, 비밀번호)
- TokenResponse: JWT 토큰 응답 DTO (accessToken, refreshToken, tokenType, expiresIn)
- RefreshTokenRequest: 리프레시 토큰 요청 DTO

### 설정 클래스
- JwtConfig: JWT 설정 관리 클래스 (application.yml에서 설정값 관리)
- SecurityConfig: Spring Security 설정
  - 회원가입, 로그인, 리프레시 토큰 경로 permitAll 설정
  - JWT 인증 필터 추가
  - BCryptPasswordEncoder 빈 등록

### 유틸리티
- JwtUtil: JWT 토큰 생성 및 검증 유틸리티
  - Access Token 생성 (기본 1시간)
  - Refresh Token 생성 (기본 7일)
  - 토큰 검증 및 Claims 추출
  - 토큰 타입별 검증 (access/refresh)

### 서비스
- UserCreateService: 사용자 생성 서비스
  - 이메일 중복 검증
  - 비밀번호 암호화 처리
- AuthService: 인증 서비스
  - `signup`: 회원가입 처리
  - `login`: 로그인 처리 및 JWT 토큰 발급
  - `refreshToken`: 리프레시 토큰을 통한 Access Token 갱신

### 컨트롤러
- AuthController: 인증 관련 REST API
  - `POST /users/signup`: 회원가입
  - `POST /users/login`: 로그인
  - `POST /users/refresh`: 리프레시 토큰 갱신

### 기타
- `application.yml`에 JWT 설정 추가 (secret, access-token-expiration, refresh-token-expiration)
- 로그인 시 Refresh Token을 User 엔티티에 저장
- 리프레시 토큰 검증 시 DB에 저장된 토큰과 일치 여부 확인

## 🧪 테스트 방법

1. 회원가입 테스트
```
   POST /api/users/signup
   {
     "email": "test@example.com",
     "name": "테스트 사용자",
     "password": "password123",
     "phone": "010-1234-5678",
     "termsOfServiceAgreed": true,
     "privacyPolicyAgreed": true,
     "marketingAgreed": false
   }
```
   - 이메일 중복 시 `USER_ALREADY_EXISTS` 예외 발생 확인
   - 필수 약관 미동의 시 검증 오류 발생 확인

2. 로그인 테스트
```
   POST /api/users/login
   {
     "email": "test@example.com",
     "password": "password123"
   }
```
   - 올바른 자격증명 시 Access Token 및 Refresh Token 발급 확인
   - 잘못된 자격증명 시 `INVALID_CREDENTIALS` 예외 발생 확인
   - 응답에 `accessToken`, `refreshToken`, `expiresIn` 포함 확인

3. 리프레시 토큰 갱신 테스트
```
   POST /api/users/refresh
   {
     "refreshToken": "발급받은_refresh_token"
   }
```
   - 유효한 리프레시 토큰으로 새로운 Access Token 및 Refresh Token 발급 확인
   - 만료된 리프레시 토큰 시 `EXPIRED_REFRESH_TOKEN` 예외 발생 확인
   - DB에 저장된 토큰과 불일치 시 `INVALID_REFRESH_TOKEN` 예외 발생 확인

5. JWT 토큰 검증
   - 발급된 Access Token을 JWT 디코더로 검증하여 userId, email, type(access) Claims 확인
   - 발급된 Refresh Token을 JWT 디코더로 검증하여 userId, email, type(refresh) Claims 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- JWT 토큰 설정은 `application.yml`에서 환경 변수로 관리됩니다.
  - `JWT_SECRET`: JWT 서명 키
  - `JWT_ACCESS_TOKEN_EXPIRATION`: Access Token 만료 시간 (기본 1시간)
  - `JWT_REFRESH_TOKEN_EXPIRATION`: Refresh Token 만료 시간 (기본 7일)
- 로그인 시 Refresh Token은 User 엔티티에 저장되며, 리프레시 토큰 갱신 시 DB에 저장된 토큰과 일치 여부를 확인합니다.
- 이메일 인증 기능은 현재 주석 처리되어 있으며, 향후 이메일 인증 기능 추가 시 활성화 예정입니다.

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #26  #27  