### PR TITLE
feat(user-service): Redis 블랙리스트를 통한 로그아웃 기능 구현 #34

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -49,7 +49,13 @@
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <module name="WhitespaceAround">
+            <!-- Google Java Format과 호환: 빈 블록에 공백 허용 -->
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+        </module>
 
         <!-- 수정자 검사 -->
         <module name="ModifierOrder"/>

--- a/services/user-service/src/main/java/com/paystream/user/config/RedisConfig.java
+++ b/services/user-service/src/main/java/com/paystream/user/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.paystream.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/filter/JwtAuthenticationFilter.java
+++ b/services/user-service/src/main/java/com/paystream/user/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.paystream.user.filter;
+
+import com.paystream.user.service.TokenBlacklistService;
+import com.paystream.user.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final TokenBlacklistService tokenBlacklistService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        // Authorization 헤더가 없거나 Bearer로 시작하지 않으면 다음 필터로
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            // Bearer 제거
+            String token = authHeader.substring(7);
+
+            // 블랙리스트 확인
+            if (tokenBlacklistService.isBlacklisted(token)) {
+                log.warn("블랙리스트에 등록된 토큰입니다: {}", token);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"error\":\"토큰이 로그아웃되었습니다.\"}");
+                return;
+            }
+
+            // 토큰 검증
+            if (jwtUtil.validateToken(token, "access")) {
+                // 사용자 ID 추출
+                Long userId = jwtUtil.extractUserId(token);
+                String email = jwtUtil.extractEmail(token);
+
+                // SecurityContext에 인증 정보 설정
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                java.util.Collections.singletonList(
+                                        new SimpleGrantedAuthority("ROLE_USER")));
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("JWT 인증 성공: userId={}, email={}", userId, email);
+            }
+        } catch (Exception e) {
+            log.error("JWT 인증 중 오류 발생", e);
+            // 인증 실패 시 SecurityContext를 비우지 않고 다음 필터로 진행
+            // (다른 필터나 SecurityConfig에서 처리)
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/TokenBlacklistService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/TokenBlacklistService.java
@@ -1,0 +1,62 @@
+package com.paystream.user.service;
+
+import com.paystream.user.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private static final String BLACKLIST_PREFIX = "blacklist:token:";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 토큰을 블랙리스트에 추가
+     *
+     * @param token 블랙리스트에 추가할 토큰
+     */
+    public void addToBlacklist(String token) {
+        try {
+            // 토큰에서 만료 시간 추출
+            Claims claims = jwtUtil.extractClaims(token);
+            long expirationTime = claims.getExpiration().getTime();
+            long currentTime = System.currentTimeMillis();
+            long ttl = expirationTime - currentTime;
+
+            // 만료 시간이 지나지 않았다면 블랙리스트에 추가
+            if (ttl > 0) {
+                String key = BLACKLIST_PREFIX + token;
+                redisTemplate.opsForValue().set(key, "blacklisted", ttl, TimeUnit.MILLISECONDS);
+                log.debug("토큰이 블랙리스트에 추가되었습니다. TTL: {}ms", ttl);
+            }
+        } catch (Exception e) {
+            log.error("블랙리스트 추가 중 오류 발생", e);
+            throw new RuntimeException("블랙리스트 추가 실패", e);
+        }
+    }
+
+    /**
+     * 토큰이 블랙리스트에 있는지 확인
+     *
+     * @param token 확인할 토큰
+     * @return 블랙리스트에 있으면 true, 없으면 false
+     */
+    public boolean isBlacklisted(String token) {
+        try {
+            String key = BLACKLIST_PREFIX + token;
+            Boolean exists = redisTemplate.hasKey(key);
+            return Boolean.TRUE.equals(exists);
+        } catch (Exception e) {
+            log.error("블랙리스트 확인 중 오류 발생", e);
+            // 오류 발생 시 안전하게 false 반환 (서비스 중단 방지)
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
JWT Access Token을 즉시 무효화하기 위해 Redis를 활용한 블랙리스트 기능 구현 및 로그아웃 시 Access Token을 Redis에 저장하여 토큰 만료 전까지 해당 토큰의 사용 차단
- Redis를 활용한 토큰 블랙리스트 관리 시스템 구축
- JWT 인증 필터에 블랙리스트 확인 로직 추가
- 로그아웃된 토큰의 즉시 무효화 보장

## 🔍 변경 사항

### 설정 클래스
- RedisConfig: Redis 연결 설정 클래스 생성
  - `RedisTemplate<String, String>` 빈 등록
  - Key/Value 직렬화를 `StringRedisSerializer`로 설정

### 서비스
- TokenBlacklistService: Redis 기반 토큰 블랙리스트 관리 서비스
  - `addToBlacklist(String token)`: 토큰을 블랙리스트에 추가
    - JWT Claims에서 만료 시간 추출
    - 토큰 만료 시간까지 TTL 설정하여 Redis에 저장
    - Key 형식: `blacklist:token:{token}`
  - `isBlacklisted(String token)`: 토큰이 블랙리스트에 있는지 확인
    - Redis Key 존재 여부 확인
    - 예외 발생 시 안전하게 `false` 반환 (서비스 중단 방지)

### 필터
- JwtAuthenticationFilter: 블랙리스트 확인 기능 추가
  - JWT 토큰 검증 전에 블랙리스트 확인
  - 블랙리스트에 등록된 토큰인 경우 401 Unauthorized 응답
  - 에러 메시지: `{"error":"토큰이 로그아웃되었습니다."}`

### 기타
- Checkstyle 설정 개선: Google Java Format과 호환되도록 설정
  - 빈 블록(생성자, 메서드, 타입, 루프)에 공백 허용 옵션 추가

## 🧪 테스트 방법

1. 로그아웃 후 토큰 사용 불가 확인
   ```
   # 1. 로그인하여 Access Token 발급

   POST /api/users/login
   {
     "email": "test@example.com",
     "password": "password123"
   }
   # 응답: `{ "accessToken": "...", "refreshToken": "..." }`

   # 2. 로그아웃 (Access Token을 블랙리스트에 추가)

   POST /api/users/logout
   Authorization: Bearer {accessToken}

   # 3. 로그아웃된 토큰으로 인증 필요한 API 호출

   GET /api/users/{id}
   Authorization: Bearer {accessToken}
   # 예상 응답: 401 Unauthorized
   # { "error": "토큰이 로그아웃되었습니다." }
   ```

2. Redis에 블랙리스트 저장 확인
   ```
   # Redis CLI에서 확인
   redis-cli
   > KEYS blacklist:token:*
   > TTL blacklist:token:{token}
   # TTL이 토큰의 남은 만료 시간과 일치하는지 확인
   ```
3. 토큰 만료 후 자동 삭제 확인
   - 로그아웃 후 Redis에 저장된 토큰의 TTL 확인
   - 토큰 만료 시간이 지나면 Redis에서 자동으로 삭제되는지 확인
   - `redis-cli`에서 `TTL blacklist:token:{token}` 명령어로 확인

4. 정상 토큰은 계속 사용 가능 확인
   - 로그아웃하지 않은 다른 사용자의 토큰으로 API 호출
   - 정상적으로 인증되어 API가 동작하는지 확인

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항

- Redis 연결 정보는 `application-local.yml`에서 환경 변수로 관리됩니다.
  - `REDIS_HOST`: Redis 호스트 (기본값: localhost)
  - `REDIS_PORT`: Redis 포트 (기본값: 6379)
  - `REDIS_PASSWORD`: Redis 비밀번호 (선택사항)
- 블랙리스트에 저장된 토큰은 토큰의 만료 시간까지 Redis에 유지되며, 만료 후 자동으로 삭제됩니다.
- `TokenBlacklistService`는 예외 발생 시 안전하게 `false`를 반환하여 Redis 장애 시에도 서비스가 중단되지 않도록 설계되었습니다.
- Checkstyle 설정 개선은 Google Java Format과의 호환성을 위해 추가되었습니다.

## 📎 참고 이슈

Ref: #34 