### PR TITLE
feat(user-service): 사용자 CRUD 기능 구현 #28

### DIFF
--- a/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
@@ -2,7 +2,9 @@ package com.paystream.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
+@EnableDiscoveryClient
 @SpringBootApplication
 public class PaymentServiceApplication {
 

--- a/services/user-service/src/main/java/com/paystream/user/controller/UserController.java
+++ b/services/user-service/src/main/java/com/paystream/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.paystream.user.controller;
+
+import com.paystream.core.BaseResponse;
+import com.paystream.user.dto.request.UserUpdateRequest;
+import com.paystream.user.dto.response.UserResponse;
+import com.paystream.user.service.UserDeleteService;
+import com.paystream.user.service.UserFindService;
+import com.paystream.user.service.UserUpdateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserFindService userFindService;
+    private final UserUpdateService userUpdateService;
+    private final UserDeleteService userDeleteService;
+
+    @GetMapping("/{id}")
+    public BaseResponse<UserResponse> findById(@PathVariable Long id) {
+        UserResponse user = userFindService.findById(id);
+        return BaseResponse.ok(user);
+    }
+
+    @PutMapping("/{id}")
+    public BaseResponse<UserResponse> update(
+            @PathVariable Long id, @Valid @RequestBody UserUpdateRequest request) {
+        UserResponse response = userUpdateService.update(id, request);
+        return BaseResponse.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public BaseResponse<String> delete(@PathVariable Long id) {
+        userDeleteService.delete(id);
+        return BaseResponse.ok("성공적으로 삭제되었습니다.");
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/request/UserUpdateRequest.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.paystream.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    private String name;
+
+    private String phone;
+}

--- a/services/user-service/src/main/java/com/paystream/user/dto/response/UserResponse.java
+++ b/services/user-service/src/main/java/com/paystream/user/dto/response/UserResponse.java
@@ -1,0 +1,46 @@
+package com.paystream.user.dto.response;
+
+import com.paystream.user.entity.AuthProvider;
+import com.paystream.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String phone;
+    private AuthProvider provider;
+    private Boolean emailVerified;
+    private Boolean termsOfServiceAgreed;
+    private Boolean privacyPolicyAgreed;
+    private Boolean marketingAgreed;
+    private LocalDateTime termsAgreedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static UserResponse of(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .phone(user.getPhone())
+                .provider(user.getProvider())
+                .emailVerified(user.getEmailVerified())
+                .termsOfServiceAgreed(user.getTermsOfServiceAgreed())
+                .privacyPolicyAgreed(user.getPrivacyPolicyAgreed())
+                .marketingAgreed(user.getMarketingAgreed())
+                .termsAgreedAt(user.getTermsAgreedAt())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/UserDeleteService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/UserDeleteService.java
@@ -1,0 +1,26 @@
+package com.paystream.user.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.user.entity.User;
+import com.paystream.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeleteService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void delete(Long id) {
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        userRepository.delete(user);
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/UserFindService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/UserFindService.java
@@ -1,0 +1,36 @@
+package com.paystream.user.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.user.dto.response.UserResponse;
+import com.paystream.user.entity.User;
+import com.paystream.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class UserFindService {
+
+    private final UserRepository userRepository;
+
+    public UserResponse findById(Long id) {
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        return UserResponse.of(user);
+    }
+
+    public UserResponse findByEmail(String email) {
+        User user =
+                userRepository
+                        .findByEmail(email)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        return UserResponse.of(user);
+    }
+}

--- a/services/user-service/src/main/java/com/paystream/user/service/UserUpdateService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/UserUpdateService.java
@@ -1,0 +1,30 @@
+package com.paystream.user.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.user.dto.request.UserUpdateRequest;
+import com.paystream.user.dto.response.UserResponse;
+import com.paystream.user.entity.User;
+import com.paystream.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUpdateService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserResponse update(Long id, UserUpdateRequest request) {
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.USER_NOT_FOUND));
+
+        user.update(request.getName(), request.getPhone());
+
+        return UserResponse.of(user);
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요

user-service에 사용자 조회, 수정, 삭제 기능 구현. 인증된 사용자가 자신의 정보를 조회하고 수정하며, 회원 탈퇴를 할 수 있는 API 제공.

## 🔍 변경 사항

- DTO 추가
  - `UserResponse`: 사용자 정보 응답 DTO (이메일, 이름, 전화번호, 소셜 로그인 정보 등)
  - `UserUpdateRequest`: 사용자 정보 수정 요청 DTO (이름, 전화번호)

- Service 계층 구현
  - `UserFindService`: 사용자 조회 서비스 (ID, 이메일로 조회)
  - `UserUpdateService`: 사용자 정보 수정 서비스
  - `UserDeleteService`: 사용자 삭제 서비스

- Controller 계층 구현
  - `UserController`: 사용자 CRUD API 엔드포인트
    - `GET /users/{id}`: 사용자 조회
    - `PUT /users/{id}`: 사용자 정보 수정
    - `DELETE /users/{id}`: 사용자 삭제

- Entity 수정
  - `User` 엔티티에 `update(String name, String phone)` 메서드 추가

- 기타
  - `PaymentServiceApplication`에 `@EnableDiscoveryClient` 추가 (Eureka 등록 보완)

## 🧪 테스트 방법

1. 사용자 조회 테스트
   ```bash
   # 인증 토큰 필요
   GET /api/users/{id}
   Authorization: Bearer {accessToken}
   ```

2. 사용자 정보 수정 테스트
   ```bash
   # 인증 토큰 필요
   PUT /api/users/{id}
   Authorization: Bearer {accessToken}
   Content-Type: application/json
   
   {
     "name": "수정된 이름",
     "phone": "010-1234-5678"
   }
   ```

3. 사용자 삭제 테스트
   ```bash
   # 인증 토큰 필요
   DELETE /api/users/{id}
   Authorization: Bearer {accessToken}
   ```

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항

- CRUD API는 인증이 필요합니다 (`SecurityConfig`에서 `/users/{id}` 경로는 인증 필수)
- 사용자 삭제는 물리적 삭제(하드 삭제)로 구현되어 있습니다. 추후 소프트 삭제로 변경 가능합니다.
- `UserResponse`는 민감한 정보(비밀번호, 리프레시 토큰 등)를 제외한 사용자 정보만 반환합니다.

## 📎 참고 이슈

Ref: #28 