### PR TITLE
feat(dev-scripts): Docker Compose를 통한 Redis 자동 실행 및 스크립트 개선 #29, #30

### DIFF
--- a/dev-scripts/start.sh
+++ b/dev-scripts/start.sh
@@ -37,10 +37,49 @@ echo -e "${GREEN}========================================${NC}"
 # 프로젝트 루트로 이동
 cd "$PROJECT_ROOT"
 
-# Gradle Wrapper 실행 권한 확인
-if [ ! -x "./gradlew" ]; then
-    chmod +x ./gradlew
-fi
+# .env 파일 로드 함수
+load_env_file() {
+    local env_file="$PROJECT_ROOT/.env"
+    
+    if [ ! -f "$env_file" ]; then
+        echo -e "${YELLOW}👿  .env 파일을 찾을 수 없습니다. 기본값을 사용합니다.${NC}"
+        return
+    fi
+    
+    echo -e "${GREEN}📄 .env 파일 로드 중...${NC}"
+    
+    # .env 파일을 읽어서 환경 변수로 export
+    # 형식: KEY: "value" 또는 KEY: value
+    while IFS= read -r line || [ -n "$line" ]; do
+        # 앞뒤 공백 제거
+        line=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        
+        # 빈 줄이나 주석 줄 건너뛰기
+        if [[ -z "$line" || "$line" =~ ^# ]]; then
+            continue
+        fi
+        
+        # KEY: "value" 또는 KEY: value 형식 파싱
+        if [[ "$line" =~ ^([^:]+):[[:space:]]*(.+)$ ]]; then
+            local key=$(echo "${BASH_REMATCH[1]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            local value=$(echo "${BASH_REMATCH[2]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            
+            # 따옴표 제거 (앞뒤 따옴표가 있는 경우)
+            if [[ "$value" =~ ^\".*\"$ ]]; then
+                value="${value#\"}"
+                value="${value%\"}"
+            fi
+            
+            # 환경 변수로 export
+            export "$key=$value"
+        fi
+    done < "$env_file"
+    
+    echo -e "${GREEN}❤️ .env 파일 로드 완료${NC}"
+}
+
+# .env 파일 로드
+load_env_file
 
 # 포트 사용 중인지 확인하는 함수 (LISTENING 상태만 확인)
 check_port() {
@@ -78,6 +117,227 @@ check_port() {
     return 1
 }
 
+# Redis 설정 (기본값)
+REDIS_HOST=${REDIS_HOST:-localhost}
+REDIS_PORT=${REDIS_PORT:-6379}
+REDIS_CONTAINER_NAME="paystream-redis"
+
+# Docker가 실행 중인지 확인하는 함수
+is_docker_running() {
+    if ! command -v docker > /dev/null 2>&1; then
+        return 1
+    fi
+    # Docker daemon이 실행 중인지 확인 (docker ps로 실제 연결 테스트)
+    # 오류 메시지는 stderr로 리다이렉트하여 숨김
+    docker ps > /dev/null 2>&1
+    return $?
+}
+
+# Docker Desktop 시작 함수 (macOS & Windows)
+start_docker_desktop() {
+    # macOS
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if [ -d "/Applications/Docker.app" ]; then
+            echo -e "${GREEN}🐳 Docker Desktop 시작 중... (macOS)${NC}"
+            open -a Docker > /dev/null 2>&1
+            _wait_for_docker_daemon
+            return $?
+        else
+            echo -e "${YELLOW}⚠️  Docker Desktop이 설치되어 있지 않습니다.${NC}"
+            return 1
+        fi
+    # Windows (Git Bash, WSL, MSYS2 등)
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "win32" ]]; then
+        # Windows에서 Docker Desktop 경로 확인
+        local docker_paths=(
+            "/c/Program Files/Docker/Docker/Docker Desktop.exe"
+            "/c/Program Files (x86)/Docker/Docker/Docker Desktop.exe"
+            "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe"
+            "C:\\Program Files (x86)\\Docker\\Docker\\Docker Desktop.exe"
+        )
+        
+        local docker_found=""
+        for path in "${docker_paths[@]}"; do
+            if [ -f "$path" ] || [ -f "$(cygpath -u "$path" 2>/dev/null)" ]; then
+                docker_found="$path"
+                break
+            fi
+        done
+        
+        if [ -n "$docker_found" ]; then
+            echo -e "${GREEN}🐳 Docker Desktop 시작 중... (Windows)${NC}"
+            # Windows에서 Docker Desktop 시작
+            if command -v cmd.exe > /dev/null 2>&1; then
+                # Git Bash에서 Windows 명령 실행
+                cmd.exe //c start "" "$docker_found" > /dev/null 2>&1
+            else
+                # 직접 실행 시도
+                "$docker_found" > /dev/null 2>&1 &
+            fi
+            _wait_for_docker_daemon
+            return $?
+        else
+            echo -e "${YELLOW}⚠️  Docker Desktop이 설치되어 있지 않습니다.${NC}"
+            return 1
+        fi
+    # Linux
+    else
+        echo -e "${YELLOW}⚠️  Linux에서는 Docker Desktop 자동 시작을 지원하지 않습니다.${NC}"
+        echo -e "${YELLOW}💡 Docker daemon을 수동으로 시작하세요: ${NC}sudo systemctl start docker"
+        return 1
+    fi
+}
+
+# Docker daemon이 준비될 때까지 대기하는 헬퍼 함수
+_wait_for_docker_daemon() {
+    local max_wait=60
+    local waited=0
+    
+    while [ $waited -lt $max_wait ]; do
+        if docker ps > /dev/null 2>&1; then
+            echo -e "${GREEN}🐳 Docker Desktop 시작 완료${NC}"
+            return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+        # 커서를 같은 줄에 유지하면서 진행 상황 표시
+        echo -ne "\r${YELLOW}⏳ Docker daemon 준비 중... (${waited}초/${max_wait}초)${NC}"
+    done
+    echo "" # 줄바꿈
+    echo -e "${RED}👿 Docker Desktop 시작 타임아웃 (60초)${NC}"
+    return 1
+}
+
+# Redis 시작 함수
+start_redis() {
+    echo -e "${GREEN}❤️‍🔥 Redis 시작 중...${NC}"
+    
+    # 포트가 이미 사용 중인지 확인
+    if check_port "$REDIS_PORT"; then
+        echo -e "${YELLOW}👿  Redis 포트 $REDIS_PORT가 이미 사용 중입니다.${NC}"
+        
+        # Docker Compose로 실행 중인지 확인
+        if is_docker_running; then
+            if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+                echo -e "${GREEN}🐳 Redis Docker Compose 컨테이너가 이미 실행 중입니다.${NC}"
+                return
+            fi
+        fi
+        
+        # Docker 컨테이너로 실행 중인지 확인
+        if is_docker_running; then
+            if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+                echo -e "${GREEN}🐳 Redis Docker 컨테이너가 이미 실행 중입니다.${NC}"
+                return
+            fi
+        fi
+        
+        echo -e "${YELLOW}👿  기존 Redis 인스턴스를 사용합니다.${NC}"
+        return
+    fi
+    
+    # Docker가 실행 중이 아니면 자동으로 시작 시도
+    if ! is_docker_running; then
+        echo -e "${YELLOW}🐳 Docker daemon이 실행 중이 아닙니다. Docker Desktop을 시작합니다...${NC}"
+        if start_docker_desktop; then
+            echo -e "${GREEN}🐳 Docker Desktop 시작 완료, Redis 시작을 계속합니다.${NC}"
+        else
+            echo -e "${RED}👿 Docker Desktop 시작 실패. Redis 없이 서비스를 계속 실행합니다.${NC}"
+            echo -e "${YELLOW}💡 수동으로 Docker Desktop을 시작한 후 다시 실행하세요.${NC}"
+            return
+        fi
+    fi
+    
+    # Docker가 실행 중인 경우에만 Docker 관련 명령 실행
+    if is_docker_running; then
+        # Docker Compose로 Redis 시작 시도 (우선)
+        if [ -f "$PROJECT_ROOT/docker-compose.yml" ]; then
+            if command -v docker-compose > /dev/null 2>&1; then
+                echo -e "${GREEN}🐳 Docker Compose로 Redis 시작 시도 중...${NC}"
+                cd "$PROJECT_ROOT"
+                if docker-compose up -d redis > /dev/null 2>&1; then
+                    sleep 2
+                    if check_port "$REDIS_PORT"; then
+                        echo -e "${GREEN}🐳 Redis Docker Compose 시작 완료${NC}"
+                        return
+                    fi
+                fi
+            elif docker compose version > /dev/null 2>&1; then
+                # Docker Compose V2 (docker compose)
+                echo -e "${GREEN}🐳 Docker Compose V2로 Redis 시작 시도 중...${NC}"
+                cd "$PROJECT_ROOT"
+                if docker compose up -d redis > /dev/null 2>&1; then
+                    sleep 2
+                    if check_port "$REDIS_PORT"; then
+                        echo -e "${GREEN}🐳 Redis Docker Compose 시작 완료${NC}"
+                        return
+                    fi
+                fi
+            fi
+        fi
+        
+        # Docker Compose가 없거나 실패한 경우 기존 방식으로 시도
+        echo -e "${GREEN}🐳 Docker로 Redis 시작 시도 중...${NC}"
+        
+        # 기존 컨테이너가 중지된 상태로 있는지 확인
+        if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+            echo -e "${YELLOW}🐳 기존 Redis 컨테이너 시작 중...${NC}"
+            if docker start "$REDIS_CONTAINER_NAME" > /dev/null 2>&1; then
+                sleep 2
+                if check_port "$REDIS_PORT"; then
+                    echo -e "${GREEN}🐳 Redis Docker 컨테이너 시작 완료${NC}"
+                    return
+                fi
+            fi
+        fi
+        
+        # 새 컨테이너 생성 및 시작
+        echo -e "${GREEN}🐳 새 Redis Docker 컨테이너 생성 중...${NC}"
+        if docker run -d \
+            --name "$REDIS_CONTAINER_NAME" \
+            -p "${REDIS_PORT}:6379" \
+            --restart unless-stopped \
+            redis:7-alpine > /dev/null 2>&1; then
+            sleep 2
+            if check_port "$REDIS_PORT"; then
+                echo -e "${GREEN}🐳 Redis Docker 컨테이너 시작 완료${NC}"
+                return
+            fi
+        fi
+    fi
+    
+    # Docker가 없거나 실패한 경우 로컬 redis-server 확인
+    if command -v redis-server > /dev/null 2>&1; then
+        echo -e "${GREEN}🖥️  로컬 Redis 서버 시작 시도 중...${NC}"
+        redis-server --port "$REDIS_PORT" --daemonize yes > /dev/null 2>&1
+        sleep 2
+        if check_port "$REDIS_PORT"; then
+            echo -e "${GREEN}🖥️ 로컬 Redis 서버 시작 완료${NC}"
+            return
+        fi
+    fi
+    
+    # 모든 방법 실패
+    if ! is_docker_running; then
+        echo -e "${RED}👿 Redis 시작 실패: Docker daemon이 실행 중이 아닙니다.${NC}"
+        echo -e "${YELLOW}💡 Docker Desktop을 시작하거나 다음 명령으로 Docker를 시작하세요:${NC}"
+        echo -e "  ${YELLOW}open -a Docker${NC} (macOS)"
+    else
+        echo -e "${RED}👿 Redis 시작 실패. 다음 중 하나를 설치하세요:${NC}"
+        echo -e "  1. Docker & Docker Compose: ${YELLOW}https://www.docker.com/get-started${NC}"
+        echo -e "  2. Redis: ${YELLOW}https://redis.io/download${NC}"
+    fi
+    echo -e "${YELLOW}⚠️  Redis 없이 서비스를 계속 실행합니다. (토큰 블랙리스트 기능이 작동하지 않을 수 있습니다)${NC}"
+}
+
+# Gradle Wrapper 실행 권한 확인
+if [ ! -x "./gradlew" ]; then
+    chmod +x ./gradlew
+fi
+
+# Redis 시작 (Eureka Server보다 먼저)
+start_redis
+
 # 서비스 실행 함수
 start_service() {
     local service_name=$1
@@ -102,6 +362,7 @@ start_service() {
     echo -e "${GREEN}❤️ $service_name 시작 중... (포트: $port)${NC}"
     
     # 서비스 실행 (백그라운드)
+    # export된 환경 변수는 자동으로 자식 프로세스에 상속됨
     nohup ./gradlew :services:${service_name}:bootRun > "$PID_DIR/${service_name}.log" 2>&1 &
     local pid=$!
     
@@ -132,6 +393,8 @@ echo ""
 echo -e "서비스 상태 확인:"
 echo -e "  - Eureka Dashboard: ${GREEN}http://localhost:8761${NC}"
 echo -e "  - API Gateway: ${GREEN}http://localhost:8000${NC}"
+echo -e "  - Swagger UI: ${GREEN}http://localhost:8000/swagger-ui.html${NC}"
+echo -e "  - Redis: ${GREEN}localhost:${REDIS_PORT}${NC}"
 echo ""
 echo -e "로그 확인: ${YELLOW}dev-scripts/pids/*.log${NC}"
 echo -e "서비스 종료: ${YELLOW}./dev-scripts/stop.sh${NC}"

--- a/dev-scripts/stop.sh
+++ b/dev-scripts/stop.sh
@@ -31,6 +31,10 @@ SERVICES=(
     "eureka-server:8761"
 )
 
+# Redis 설정 (기본값)
+REDIS_PORT=${REDIS_PORT:-6379}
+REDIS_CONTAINER_NAME="paystream-redis"
+
 # 서비스 종료 함수
 stop_service() {
     local service_name=$1
@@ -90,7 +94,7 @@ stop_service() {
         done
         echo -e "${GREEN}💚 $service_name 종료됨${NC}"
     else
-        echo -e "${YELLOW}  $service_name는 실행 중이 아닙니다.${NC}"
+        echo -e "${YELLOW}🛑 $service_name (포트: $port)는 실행 중이 아닙니다.${NC}"
     fi
 }
 
@@ -113,6 +117,96 @@ if [ -n "$java_pids" ]; then
         fi
     done
 fi
+
+# Docker가 실행 중인지 확인하는 함수
+is_docker_running() {
+    if ! command -v docker > /dev/null 2>&1; then
+        return 1
+    fi
+    # Docker daemon이 실행 중인지 확인 (오류 메시지 숨김)
+    docker info > /dev/null 2>&1
+    return $?
+}
+
+# Docker가 실행 중인지 확인하는 함수
+is_docker_running() {
+    if ! command -v docker > /dev/null 2>&1; then
+        return 1
+    fi
+    # Docker daemon이 실행 중인지 확인 (오류 메시지 숨김)
+    docker info > /dev/null 2>&1
+    return $?
+}
+
+# Redis 종료 함수
+stop_redis() {
+    echo -e "${YELLOW}🛑 Redis 종료 중...${NC}"
+    
+    # Docker가 실행 중인 경우에만 Docker 관련 명령 실행
+    if is_docker_running; then
+        # Docker Compose로 실행 중인지 확인 및 종료
+        if [ -f "$PROJECT_ROOT/docker-compose.yml" ]; then
+            if command -v docker-compose > /dev/null 2>&1; then
+                if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+                    echo -e "${YELLOW}🐳 Redis Docker Compose 종료 중...${NC}"
+                    cd "$PROJECT_ROOT"
+                    docker-compose stop redis > /dev/null 2>&1 || true
+                    echo -e "${GREEN}💚 Redis Docker Compose 종료됨${NC}"
+                    return
+                fi
+            elif docker compose version > /dev/null 2>&1; then
+                # Docker Compose V2
+                if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+                    echo -e "${YELLOW}🐳 Redis Docker Compose V2 종료 중...${NC}"
+                    cd "$PROJECT_ROOT"
+                    docker compose stop redis > /dev/null 2>&1 || true
+                    echo -e "${GREEN}💚 Redis Docker Compose 종료됨${NC}"
+                    return
+                fi
+            fi
+        fi
+        
+        # Docker 컨테이너로 실행 중인지 확인
+        if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER_NAME}$"; then
+            echo -e "${YELLOW}🐳 Redis Docker 컨테이너 종료 중...${NC}"
+            docker stop "$REDIS_CONTAINER_NAME" > /dev/null 2>&1 || true
+            echo -e "${GREEN}💚 Redis Docker 컨테이너 종료됨${NC}"
+            return
+        fi
+    fi
+    
+    # 로컬 redis-server 프로세스 확인
+    local redis_pids=""
+    if command -v lsof > /dev/null 2>&1; then
+        redis_pids=$(lsof -ti:$REDIS_PORT 2>/dev/null || true)
+    elif command -v ss > /dev/null 2>&1; then
+        redis_pids=$(ss -lntp 2>/dev/null | grep ":$REDIS_PORT " | sed -n 's/.*pid=\([0-9]*\).*/\1/p' | sort -u || true)
+    fi
+    
+    if [ -n "$redis_pids" ]; then
+        for pid in $redis_pids; do
+            # redis-server 프로세스인지 확인
+            if ps -p "$pid" > /dev/null 2>&1; then
+                local process_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "")
+                if echo "$process_name" | grep -q "redis"; then
+                    echo -e "${YELLOW}🖥️  로컬 Redis 서버 종료 중... (PID: $pid)${NC}"
+                    kill "$pid" 2>/dev/null || true
+                    sleep 1
+                    if ps -p "$pid" > /dev/null 2>&1; then
+                        kill -9 "$pid" 2>/dev/null || true
+                    fi
+                    echo -e "${GREEN}💚 로컬 Redis 서버 종료됨${NC}"
+                    return
+                fi
+            fi
+        done
+    fi
+    
+    echo -e "${YELLOW}⚠️  Redis가 실행 중이 아닙니다.${NC}"
+}
+
+# Redis 종료
+stop_redis
 
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}모든 서비스 종료 완료!${NC}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+
+services:
+  # Redis - 토큰 블랙리스트 및 캐시용
+  redis:
+    image: redis:7-alpine
+    container_name: paystream-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+    networks:
+      - paystream-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # PostgreSQL - 로컬 개발용 (선택적)
+  # 개별 DB를 사용하는 경우 주석 처리하세요
+  # postgres:
+  #   image: postgres:16-alpine
+  #   container_name: paystream-postgres
+  #   ports:
+  #     - "${POSTGRES_PORT:-5432}:5432"
+  #   environment:
+  #     POSTGRES_DB: ${POSTGRES_DB:-postgres}
+  #     POSTGRES_USER: ${POSTGRES_USER:-postgres}
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+  #   volumes:
+  #     - postgres-data:/var/lib/postgresql/data
+  #   restart: unless-stopped
+  #   networks:
+  #     - paystream-network
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+  #     interval: 10s
+  #     timeout: 5s
+  #     retries: 5
+
+volumes:
+  redis-data:
+    driver: local
+  # postgres-data:
+  #   driver: local
+
+networks:
+  paystream-network:
+    driver: bridge
+


### PR DESCRIPTION
## 📌 PR 개요
Docker Compose를 통한 Redis 자동 실행 기능 추가, `start.sh`와 `stop.sh` 스크립트 개선. 개발 환경에서 Redis를 수동으로 시작할 필요 없이 스크립트 실행 시 자동으로 시작 가능

## 🔍 변경 사항

### Docker Compose 설정
- `docker-compose.yml` 추가: Redis 서비스 설정 파일 생성
  - Redis 7-alpine 이미지 사용
  - 포트 매핑 및 볼륨 설정
  - Health check 설정
  - 네트워크 설정 (paystream-network)

### start.sh 스크립트 개선
- Redis 자동 시작 기능
  - Docker Compose 우선 사용 (docker-compose 또는 docker compose V2 지원)
  - Docker Desktop 자동 시작 기능 추가 (macOS/Windows)
  - Docker Compose 실패 시 기존 Docker 컨테이너 방식으로 폴백
  - 로컬 `redis-server` 지원 (Docker가 없는 경우)
  - Redis 상태 확인 및 중복 실행 방지

- Docker Desktop 자동 시작
  - macOS: `open -a Docker` 명령으로 자동 시작
  - Windows: Git Bash에서 Docker Desktop 실행 파일 찾아서 시작
  - Docker daemon 준비 대기 로직 추가

- 헬퍼 함수 추가
  - `is_docker_running()`: Docker daemon 실행 상태 확인
  - `start_docker_desktop()`: Docker Desktop 자동 시작
  - `start_redis()`: Redis 시작 로직 통합

### stop.sh 스크립트 개선
- Redis 자동 종료 기능
  - Docker Compose로 실행 중인 Redis 종료
  - Docker 컨테이너로 실행 중인 Redis 종료
  - 로컬 `redis-server` 프로세스 종료
  - 크로스 플랫폼 지원 (macOS/Windows/Linux)

- 헬퍼 함수 추가
  - `is_docker_running()`: Docker daemon 실행 상태 확인
  - `stop_redis()`: Redis 종료 로직 통합

## 🧪 테스트 방법

1. Redis 자동 시작 테스트
   ```bash
   ./dev-scripts/start.sh
   ```
   - Docker Compose가 있으면 우선 사용
   - Docker Desktop이 꺼져 있으면 자동으로 시작
   - Redis가 정상적으로 시작되는지 확인

2. Redis 자동 종료 테스트
   ```bash
   ./dev-scripts/stop.sh
   ```
   - 실행 중인 Redis가 정상적으로 종료되는지 확인

3. Docker Compose 직접 실행 테스트
   ```bash
   docker-compose up -d redis
   # 또는
   docker compose up -d redis
   ```

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항

- Docker Compose 우선순위: `docker-compose.yml` 파일이 있으면 Docker Compose를 우선 사용합니다.
- 폴백 메커니즘: Docker Compose 실패 시 기존 Docker 컨테이너 방식으로 자동 전환됩니다.
- 크로스 플랫폼 지원: macOS, Windows (Git Bash), Linux 모두 지원합니다.
- 에러 처리: Docker가 없거나 실패해도 서비스는 계속 실행되며, 경고 메시지만 표시됩니다.

## 📎 참고 이슈

Ref: #29  #30 