### PR TITLE
feat(user-service, payment-service): Swagger API 문서화 설정 #31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,4 +253,9 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### Environment Variables ###
+.env
+.env.local
+.env.*.local
+
 # End of https://www.toptal.com/developers/gitignore/api/intellij,visualstudiocode,eclipse,java,gradle,git,macos,windows

--- a/services/payment-service/build.gradle
+++ b/services/payment-service/build.gradle
@@ -42,6 +42,18 @@ dependencies {
     
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    
+    // DB & JPA
+    runtimeOnly 'org.postgresql:postgresql' // local, dev
+    runtimeOnly 'com.h2database:h2' // test
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    
+    // Swagger - API 문서화
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    
+    // 공통 라이브러리 가져옴
+    implementation project(':common:core')
 }
 
 dependencyManagement {

--- a/services/payment-service/src/main/java/com/paystream/payment/config/SwaggerConfig.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.paystream.payment.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .servers(
+                        List.of(
+                                new Server()
+                                        .url("http://localhost:8000/api")
+                                        .description("API Gateway")));
+    }
+
+    private Info apiInfo() {
+        return new Info().title("Payment API").description("Payment API").version("0.0.1-SNAPSHOT");
+    }
+}

--- a/services/payment-service/src/main/resources/application-local.yml
+++ b/services/payment-service/src/main/resources/application-local.yml
@@ -2,6 +2,23 @@ spring:
   config:
     activate:
       on-profile: local
+  # DB 설정
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/postgres}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+        default_batch_fetch_size: 1000
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 server:
   port: 8084
@@ -19,3 +36,4 @@ logging:
     com.paystream.payment: DEBUG
     org.springframework.cloud: DEBUG
     org.springframework.web: DEBUG
+    org.hibernate.type.descriptor.sql: DEBUG

--- a/services/payment-service/src/main/resources/application.yml
+++ b/services/payment-service/src/main/resources/application.yml
@@ -16,6 +16,16 @@ management:
     health:
       show-details: when-authorized
 
+# Swagger 설정
+springdoc:
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    tagsSorter: alpha
+    operations-sorter: alpha
+    display-request-duration: true
+
 eureka:
   client:
     service-url:

--- a/services/user-service/src/main/java/com/paystream/user/config/SwaggerConfig.java
+++ b/services/user-service/src/main/java/com/paystream/user/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.paystream.user.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .servers(
+                        List.of(
+                                new Server()
+                                        .url("http://localhost:8000/api")
+                                        .description("API Gateway")));
+    }
+
+    private Info apiInfo() {
+        return new Info().title("User API").description("User API").version("0.0.1-SNAPSHOT");
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요
user-service와 payment-service에 SpringDoc OpenAPI를 통한 Swagger API 문서화 기능 추가.

## 🔍 변경 사항

### 의존성 추가
- SpringDoc OpenAPI 의존성 추가
  - `user-service/build.gradle`: `springdoc-openapi-starter-webmvc-ui:2.8.9` 추가
  - `payment-service/build.gradle`: `springdoc-openapi-starter-webmvc-ui:2.8.9` 추가

### Swagger 설정 클래스
- SwaggerConfig 클래스 생성
  - `user-service`: `SwaggerConfig.java` 생성
  - `payment-service`: `SwaggerConfig.java` 생성
  - API Gateway를 통한 접근을 위한 서버 URL 설정 (`http://localhost:8000/api`)
  - API 정보 설정 (제목, 설명, 버전)

### Swagger UI 설정
- application.yml 설정 추가
  - `user-service`: Swagger API 문서 및 UI 활성화
  - `payment-service`: Swagger API 문서 및 UI 활성화
  - 태그 및 작업 정렬 설정 (알파벳 순)
  - 요청 지속 시간 표시 설정

### 기타
- 보안 개선: `.env` 파일을 `.gitignore`에 추가하여 민감한 정보 보호
- 설정 개선: `payment-service`의 `application-local.yml`에 PostgreSQL 설정 추가

## 🧪 테스트 방법

1. 서비스 시작
   ```bash
   ./dev-scripts/start.sh
   ```

2. Swagger UI 접근
   - API Gateway Swagger UI: `http://localhost:8000/swagger-ui.html`
   - 서비스별 Swagger UI:
     - User Service: `http://localhost:8085/swagger-ui.html`
     - Payment Service: `http://localhost:8084/swagger-ui.html`

3. API 테스트
   - Swagger UI에서 "Select a definition" 드롭다운에서 서비스 선택
   - 각 API 엔드포인트를 확인하고 "Try it out" 버튼으로 테스트
   - API Gateway를 통한 요청이 정상적으로 작동하는지 확인

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 🗣️ 공유 사항

- API Gateway 통합: Swagger UI에서 생성된 요청은 API Gateway(`http://localhost:8000/api`)를 통해 라우팅됩니다.
- 서비스별 독립 문서: 각 서비스는 독립적인 Swagger 문서를 제공하며, API Gateway에서 통합하여 확인할 수 있습니다.
- 보안: `.env` 파일이 `.gitignore`에 추가되어 민감한 정보(DB 비밀번호 등)가 Git에 커밋되지 않습니다.
- API Gateway 설정 제외: 이 PR에는 API Gateway의 Swagger 통합 설정은 포함되지 않았습니다.

## 📎 참고 이슈

Ref: #31 