### PR TITLE
feat(notification): MockBean 경고 및 Eureka 연결 경고 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "common-core build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test common-core
+        run: ./gradlew :common:core:spotlessCheck :common:core:checkstyleMain :common:core:checkstyleTest :common:core:test
 
   build-api-gateway:
     name: Build api-gateway
@@ -91,8 +105,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "api-gateway build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test api-gateway
+        run: ./gradlew :services:api-gateway:spotlessCheck :services:api-gateway:checkstyleMain :services:api-gateway:checkstyleTest :services:api-gateway:test
 
   build-eureka-server:
     name: Build eureka-server
@@ -106,8 +134,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "eureka-server build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test eureka-server
+        run: ./gradlew :services:eureka-server:spotlessCheck :services:eureka-server:checkstyleMain :services:eureka-server:checkstyleTest :services:eureka-server:test
 
   build-inventory-service:
     name: Build inventory-service
@@ -121,8 +163,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "inventory-service build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test inventory-service
+        run: ./gradlew :services:inventory-service:spotlessCheck :services:inventory-service:checkstyleMain :services:inventory-service:checkstyleTest :services:inventory-service:test
 
   build-notification-service:
     name: Build notification-service
@@ -136,8 +192,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "notification-service build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test notification-service
+        run: ./gradlew :services:notification-service:spotlessCheck :services:notification-service:checkstyleMain :services:notification-service:checkstyleTest :services:notification-service:test
 
   build-order-service:
     name: Build order-service
@@ -151,8 +221,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "order-service build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test order-service
+        run: ./gradlew :services:order-service:spotlessCheck :services:order-service:checkstyleMain :services:order-service:checkstyleTest :services:order-service:test
 
   build-payment-service:
     name: Build payment-service
@@ -166,8 +250,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "payment-service build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test payment-service
+        run: ./gradlew :services:payment-service:spotlessCheck :services:payment-service:checkstyleMain :services:payment-service:checkstyleTest :services:payment-service:test
 
   build-user-service:
     name: Build user-service
@@ -181,5 +279,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Placeholder
-        run: echo "user-service build placeholder"
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Lint & Test user-service
+        run: ./gradlew :services:user-service:spotlessCheck :services:user-service:checkstyleMain :services:user-service:checkstyleTest :services:user-service:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,3 +295,44 @@ jobs:
 
       - name: Lint & Test user-service
         run: ./gradlew :services:user-service:spotlessCheck :services:user-service:checkstyleMain :services:user-service:checkstyleTest :services:user-service:test
+
+  ci-status:
+    name: CI Status
+    needs:
+      - detect-changes
+      - build-common-core
+      - build-api-gateway
+      - build-eureka-server
+      - build-inventory-service
+      - build-notification-service
+      - build-order-service
+      - build-payment-service
+      - build-user-service
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Summarize job results
+        run: |
+          echo "detect-changes: ${{ needs.detect-changes.result }}"
+          echo "common-core: ${{ needs.build-common-core.result }}"
+          echo "api-gateway: ${{ needs.build-api-gateway.result }}"
+          echo "eureka-server: ${{ needs.build-eureka-server.result }}"
+          echo "inventory-service: ${{ needs.build-inventory-service.result }}"
+          echo "notification-service: ${{ needs.build-notification-service.result }}"
+          echo "order-service: ${{ needs.build-order-service.result }}"
+          echo "payment-service: ${{ needs.build-payment-service.result }}"
+          echo "user-service: ${{ needs.build-user-service.result }}"
+
+          if [[ "${{ needs.build-common-core.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-api-gateway.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-eureka-server.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-inventory-service.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-notification-service.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-order-service.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-payment-service.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-user-service.result }}" == "failure" ]]; then
+            echo "CI failed"
+            exit 1
+          else
+            echo "CI passed"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,29 +64,122 @@ jobs:
               - 'common/core/**'
               - 'services/**'
 
-  build-and-test:
+  build-common-core:
+    name: Build common-core
+    needs: detect-changes
+    if: needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Placeholder
+        run: echo "common-core build placeholder"
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+  build-api-gateway:
+    name: Build api-gateway
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api_gateway == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          distribution: temurin
-          java-version: '17'
-          cache: gradle
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "api-gateway build placeholder"
 
-      - name: Grant execute permission for Gradle
-        run: chmod +x gradlew
+  build-eureka-server:
+    name: Build eureka-server
+    needs: detect-changes
+    if: needs.detect-changes.outputs.eureka_server == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "eureka-server build placeholder"
 
-      - name: Run tests
-        run: ./gradlew clean test
+  build-inventory-service:
+    name: Build inventory-service
+    needs: detect-changes
+    if: needs.detect-changes.outputs.inventory_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "inventory-service build placeholder"
+
+  build-notification-service:
+    name: Build notification-service
+    needs: detect-changes
+    if: needs.detect-changes.outputs.notification_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "notification-service build placeholder"
+
+  build-order-service:
+    name: Build order-service
+    needs: detect-changes
+    if: needs.detect-changes.outputs.order_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "order-service build placeholder"
+
+  build-payment-service:
+    name: Build payment-service
+    needs: detect-changes
+    if: needs.detect-changes.outputs.payment_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "payment-service build placeholder"
+
+  build-user-service:
+    name: Build user-service
+    needs: detect-changes
+    if: needs.detect-changes.outputs.user_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Placeholder
+        run: echo "user-service build placeholder"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      common_core: ${{ steps.changes.outputs.common_core }}
+      api_gateway: ${{ steps.changes.outputs.api_gateway }}
+      eureka_server: ${{ steps.changes.outputs.eureka_server }}
+      inventory_service: ${{ steps.changes.outputs.inventory_service }}
+      notification_service: ${{ steps.changes.outputs.notification_service }}
+      order_service: ${{ steps.changes.outputs.order_service }}
+      payment_service: ${{ steps.changes.outputs.payment_service }}
+      user_service: ${{ steps.changes.outputs.user_service }}
+      any: ${{ steps.changes.outputs.any }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect module changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            common_core:
+              - 'common/core/**'
+            api_gateway:
+              - 'services/api-gateway/**'
+            eureka_server:
+              - 'services/eureka-server/**'
+            inventory_service:
+              - 'services/inventory-service/**'
+            notification_service:
+              - 'services/notification-service/**'
+            order_service:
+              - 'services/order-service/**'
+            payment_service:
+              - 'services/payment-service/**'
+            user_service:
+              - 'services/user-service/**'
+            any:
+              - 'build.gradle'
+              - 'settings.gradle'
+              - 'gradle/**'
+              - 'gradlew*'
+              - '.github/workflows/**'
+              - 'common/core/**'
+              - 'services/**'
+
   build-and-test:
     runs-on: ubuntu-latest
     permissions:

--- a/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
+++ b/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** HealthController 단위 테스트 */
@@ -17,8 +17,7 @@ class HealthControllerTests {
 
     @Autowired private MockMvc mockMvc;
 
-    // JPA Auditing에서 요구하는 매핑 컨텍스트를 목으로 등록해 WebMvcTest에서 DB 의존성을 제거
-    @MockBean private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockitoBean private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     @DisplayName("ping 엔드포인트 - 정상 응답 확인")

--- a/services/notification-service/src/test/resources/application.yml
+++ b/services/notification-service/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: notification-service-test
+  cloud:
+    discovery:
+      enabled: false
+
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false
+  instance:
+    hostname: localhost


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 테스트 코드에서 발생하는 MockBean deprecated 경고와 Eureka 연결 경고를 해결하고, CI 파이프라인을 개선했어요.

- Spring Boot 3.5에서 deprecated된 `@MockBean`을 `@MockitoBean`으로 변경
- 테스트 환경에서 Eureka 클라이언트 비활성화 설정 추가
- CI 파이프라인에 모듈별 lint/test 명령 및 결과 요약 기능 추가

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `HealthControllerTests.java`: `@MockBean` → `@MockitoBean`으로 변경하여 deprecated 경고 제거
- `test/resources/application.yml` 추가: 테스트 환경에서 Eureka 클라이언트 비활성화 설정
- `.github/workflows/ci.yml`: 
- 모듈별 lint/test 명령 추가 (spotlessCheck, checkstyleMain, checkstyleTest, test)
- ci-status job 추가하여 전체 빌드 결과 요약

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 로컬에서 테스트 실행
   ./gradlew :services:notification-service:test
      - MockBean 경고 없이 테스트 통과 확인
   - Eureka 연결 경고 없이 테스트 통과 확인

2. 전체 프로젝트 테스트 실행
   ./gradlew clean test
      - 모든 모듈의 테스트가 정상적으로 통과하는지 확인

3. CI 파이프라인 확인
   - GitHub Actions에서 PR 생성 시 자동으로 CI 실행
   - 각 모듈별 lint/test 결과 확인
   - ci-status job에서 전체 결과 요약 확인

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- Spring Boot 3.5에서 `@MockBean`이 deprecated되었으므로, 다른 테스트 코드에서도 `@MockitoBean`으로 변경이 필요할 수 있습니다.
- 테스트 환경에서 Eureka 연결 경고가 발생하는 다른 서비스가 있다면 동일한 방식으로 `test/resources/application.yml`에 Eureka 비활성화 설정을 추가하면 됩니다.

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #