### PR TITLE
test(user-service): user-service 테스트 코드 추가 및 payment-service 예외 처리 개선

### DIFF
--- a/common/core/src/main/java/com/paystream/core/exception/PayStreamExceptionAdvice.java
+++ b/common/core/src/main/java/com/paystream/core/exception/PayStreamExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.paystream.core.exception;
 import java.util.stream.Collectors;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,16 +13,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class PayStreamExceptionAdvice {
 
     @ExceptionHandler({PayStreamException.class})
-    public ExceptionResponse exceptionHandler(PayStreamException e) {
-        return ExceptionResponse.builder()
-                .code(e.getError().getCode())
-                .status(e.getError().getStatus())
-                .message(e.getMessage())
-                .build();
+    public ResponseEntity<ExceptionResponse> exceptionHandler(PayStreamException e) {
+        ExceptionResponse response =
+                ExceptionResponse.builder()
+                        .code(e.getError().getCode())
+                        .status(e.getError().getStatus())
+                        .message(e.getMessage())
+                        .build();
+        return ResponseEntity.status(e.getError().getStatus()).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ExceptionResponse handleValidationExceptions(MethodArgumentNotValidException e) {
+    public ResponseEntity<ExceptionResponse> handleValidationExceptions(
+            MethodArgumentNotValidException e) {
 
         // 오류가 발생한 모든 필드와 메시지를 추출하여 세미콜론(;)으로 연결
         String errorMessage =
@@ -34,10 +38,25 @@ public class PayStreamExceptionAdvice {
                         .collect(Collectors.joining("; "));
 
         // 유효성 검사 실패는 HTTP 400 Bad Request로 응답
-        return ExceptionResponse.builder()
-                .code(HttpStatus.BAD_REQUEST.toString())
-                .status(HttpStatus.BAD_REQUEST)
-                .message("유효성 검사 실패: " + errorMessage)
-                .build();
+        ExceptionResponse response =
+                ExceptionResponse.builder()
+                        .code(HttpStatus.BAD_REQUEST.toString())
+                        .status(HttpStatus.BAD_REQUEST)
+                        .message("유효성 검사 실패: " + errorMessage)
+                        .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionResponse> handleIllegalArgumentException(
+            IllegalArgumentException e) {
+        // IllegalArgumentException은 HTTP 400 Bad Request로 응답
+        ExceptionResponse response =
+                ExceptionResponse.builder()
+                        .code(HttpStatus.BAD_REQUEST.toString())
+                        .status(HttpStatus.BAD_REQUEST)
+                        .message(e.getMessage())
+                        .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 }

--- a/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/PaymentServiceApplication.java
@@ -1,11 +1,14 @@
 package com.paystream.payment;
 
+import com.paystream.core.exception.PayStreamExceptionAdvice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Import;
 
 @EnableDiscoveryClient
 @SpringBootApplication
+@Import(PayStreamExceptionAdvice.class)
 public class PaymentServiceApplication {
 
     public static void main(String[] args) {

--- a/services/user-service/src/test/java/com/paystream/user/UserServiceApplicationTests.java
+++ b/services/user-service/src/test/java/com/paystream/user/UserServiceApplicationTests.java
@@ -2,9 +2,13 @@ package com.paystream.user;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestPropertySource(
         properties = {
             "eureka.client.enabled=false",
@@ -12,6 +16,8 @@ import org.springframework.test.context.TestPropertySource;
             "eureka.client.fetch-registry=false"
         })
 class UserServiceApplicationTests {
+
+    @MockitoBean private RedisConnectionFactory redisConnectionFactory;
 
     @Test
     void contextLoads() {

--- a/services/user-service/src/test/java/com/paystream/user/UserServiceApplicationTests.java
+++ b/services/user-service/src/test/java/com/paystream/user/UserServiceApplicationTests.java
@@ -1,0 +1,20 @@
+package com.paystream.user;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(
+        properties = {
+            "eureka.client.enabled=false",
+            "eureka.client.register-with-eureka=false",
+            "eureka.client.fetch-registry=false"
+        })
+class UserServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // 애플리케이션 컨텍스트가 정상적으로 로드되는지 확인
+    }
+}

--- a/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
@@ -15,17 +15,18 @@ import com.paystream.user.service.AuthService;
 import com.paystream.user.service.UserCreateService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(
-        controllers = AuthController.class,
-        excludeAutoConfiguration = {
-            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
-        })
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
 @TestPropertySource(
         properties = {
             "eureka.client.enabled=false",
@@ -38,9 +39,11 @@ class AuthControllerTest {
 
     @Autowired private ObjectMapper objectMapper;
 
-    @MockBean private AuthService authService;
+    @MockitoBean private AuthService authService;
 
-    @MockBean private UserCreateService userCreateService;
+    @MockitoBean private UserCreateService userCreateService;
+
+    @MockitoBean private RedisConnectionFactory redisConnectionFactory;
 
     @Test
     void signupShouldReturnCreated() throws Exception {
@@ -61,7 +64,8 @@ class AuthControllerTest {
                         post("/users/signup")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CREATED"))
                 .andExpect(jsonPath("$.data").value(1L));
     }
 
@@ -80,7 +84,8 @@ class AuthControllerTest {
                         post("/users/signup")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"));
     }
 
     @Test
@@ -150,6 +155,8 @@ class AuthControllerTest {
     void logoutWithoutTokenShouldReturnBadRequest() throws Exception {
         // when & then
         mockMvc.perform(post("/users/logout").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("Authorization 헤더에 Bearer 토큰이 필요합니다."));
     }
 }

--- a/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
@@ -43,7 +43,7 @@ class AuthControllerTest {
     @MockBean private UserCreateService userCreateService;
 
     @Test
-    void signup_shouldReturnCreated() throws Exception {
+    void signupShouldReturnCreated() throws Exception {
         // given
         SignupRequest request =
                 SignupRequest.builder()
@@ -66,7 +66,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void signup_withInvalidRequest_shouldReturnBadRequest() throws Exception {
+    void signupWithInvalidRequestShouldReturnBadRequest() throws Exception {
         // given
         SignupRequest request =
                 SignupRequest.builder()
@@ -84,7 +84,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void login_shouldReturnOk() throws Exception {
+    void loginShouldReturnOk() throws Exception {
         // given
         LoginRequest request =
                 LoginRequest.builder().email("test@example.com").password("password123").build();
@@ -109,7 +109,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void refreshToken_shouldReturnOk() throws Exception {
+    void refreshTokenShouldReturnOk() throws Exception {
         // given
         RefreshTokenRequest request =
                 RefreshTokenRequest.builder().refreshToken("refresh-token").build();
@@ -133,7 +133,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void logout_withValidToken_shouldReturnOk() throws Exception {
+    void logoutWithValidTokenShouldReturnOk() throws Exception {
         // given
         String accessToken = "Bearer valid-access-token";
 
@@ -147,7 +147,7 @@ class AuthControllerTest {
     }
 
     @Test
-    void logout_withoutToken_shouldReturnBadRequest() throws Exception {
+    void logoutWithoutTokenShouldReturnBadRequest() throws Exception {
         // when & then
         mockMvc.perform(post("/users/logout").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());

--- a/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/AuthControllerTest.java
@@ -1,0 +1,155 @@
+package com.paystream.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paystream.user.dto.request.LoginRequest;
+import com.paystream.user.dto.request.RefreshTokenRequest;
+import com.paystream.user.dto.request.SignupRequest;
+import com.paystream.user.dto.response.TokenResponse;
+import com.paystream.user.service.AuthService;
+import com.paystream.user.service.UserCreateService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeAutoConfiguration = {
+            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "eureka.client.enabled=false",
+            "eureka.client.register-with-eureka=false",
+            "eureka.client.fetch-registry=false"
+        })
+class AuthControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private AuthService authService;
+
+    @MockBean private UserCreateService userCreateService;
+
+    @Test
+    void signup_shouldReturnCreated() throws Exception {
+        // given
+        SignupRequest request =
+                SignupRequest.builder()
+                        .email("test@example.com")
+                        .name("테스트 사용자")
+                        .password("password123")
+                        .termsOfServiceAgreed(true)
+                        .privacyPolicyAgreed(true)
+                        .build();
+
+        when(userCreateService.create(any(SignupRequest.class))).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(
+                        post("/users/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data").value(1L));
+    }
+
+    @Test
+    void signup_withInvalidRequest_shouldReturnBadRequest() throws Exception {
+        // given
+        SignupRequest request =
+                SignupRequest.builder()
+                        .email("invalid-email") // 잘못된 이메일 형식
+                        .name("") // 빈 이름
+                        .password("")
+                        .build();
+
+        // when & then
+        mockMvc.perform(
+                        post("/users/signup")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void login_shouldReturnOk() throws Exception {
+        // given
+        LoginRequest request =
+                LoginRequest.builder().email("test@example.com").password("password123").build();
+
+        TokenResponse tokenResponse =
+                TokenResponse.builder()
+                        .accessToken("access-token")
+                        .refreshToken("refresh-token")
+                        .expiresIn(3600L)
+                        .build();
+
+        when(authService.login(any(LoginRequest.class))).thenReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(
+                        post("/users/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+    }
+
+    @Test
+    void refreshToken_shouldReturnOk() throws Exception {
+        // given
+        RefreshTokenRequest request =
+                RefreshTokenRequest.builder().refreshToken("refresh-token").build();
+
+        TokenResponse tokenResponse =
+                TokenResponse.builder()
+                        .accessToken("new-access-token")
+                        .refreshToken("new-refresh-token")
+                        .expiresIn(3600L)
+                        .build();
+
+        when(authService.refreshToken(any(RefreshTokenRequest.class))).thenReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(
+                        post("/users/refresh")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("new-access-token"));
+    }
+
+    @Test
+    void logout_withValidToken_shouldReturnOk() throws Exception {
+        // given
+        String accessToken = "Bearer valid-access-token";
+
+        // when & then
+        mockMvc.perform(
+                        post("/users/logout")
+                                .header("Authorization", accessToken)
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("로그아웃되었습니다."));
+    }
+
+    @Test
+    void logout_withoutToken_shouldReturnBadRequest() throws Exception {
+        // when & then
+        mockMvc.perform(post("/users/logout").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
@@ -24,7 +24,7 @@ class PingControllerTest {
     @Autowired private MockMvc mockMvc;
 
     @Test
-    void ping_shouldReturnOk() throws Exception {
+    void pingShouldReturnOk() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/users/ping"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.service").value("user-service"))

--- a/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
@@ -2,17 +2,19 @@ package com.paystream.user.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@WebMvcTest(
-        controllers = PingController.class,
-        excludeAutoConfiguration = {
-            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
-        })
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
 @TestPropertySource(
         properties = {
             "eureka.client.enabled=false",
@@ -22,6 +24,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 class PingControllerTest {
 
     @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private RedisConnectionFactory redisConnectionFactory;
 
     @Test
     void pingShouldReturnOk() throws Exception {

--- a/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/PingControllerTest.java
@@ -1,0 +1,33 @@
+package com.paystream.user.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(
+        controllers = PingController.class,
+        excludeAutoConfiguration = {
+            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "eureka.client.enabled=false",
+            "eureka.client.register-with-eureka=false",
+            "eureka.client.fetch-registry=false"
+        })
+class PingControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    void ping_shouldReturnOk() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/users/ping"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.service").value("user-service"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status").value("UP"));
+    }
+}

--- a/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
@@ -17,17 +17,18 @@ import com.paystream.user.service.UserFindService;
 import com.paystream.user.service.UserUpdateService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(
-        controllers = UserController.class,
-        excludeAutoConfiguration = {
-            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
-        })
+@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
+@SpringBootTest
 @TestPropertySource(
         properties = {
             "eureka.client.enabled=false",
@@ -40,11 +41,13 @@ class UserControllerTest {
 
     @Autowired private ObjectMapper objectMapper;
 
-    @MockBean private UserFindService userFindService;
+    @MockitoBean private UserFindService userFindService;
 
-    @MockBean private UserUpdateService userUpdateService;
+    @MockitoBean private UserUpdateService userUpdateService;
 
-    @MockBean private UserDeleteService userDeleteService;
+    @MockitoBean private UserDeleteService userDeleteService;
+
+    @MockitoBean private RedisConnectionFactory redisConnectionFactory;
 
     @Test
     void findByIdShouldReturnOk() throws Exception {

--- a/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
@@ -1,0 +1,104 @@
+package com.paystream.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paystream.user.dto.request.UserUpdateRequest;
+import com.paystream.user.dto.response.UserResponse;
+import com.paystream.user.service.UserDeleteService;
+import com.paystream.user.service.UserFindService;
+import com.paystream.user.service.UserUpdateService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeAutoConfiguration = {
+            org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "eureka.client.enabled=false",
+            "eureka.client.register-with-eureka=false",
+            "eureka.client.fetch-registry=false"
+        })
+class UserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private UserFindService userFindService;
+
+    @MockBean private UserUpdateService userUpdateService;
+
+    @MockBean private UserDeleteService userDeleteService;
+
+    @Test
+    void findById_shouldReturnOk() throws Exception {
+        // given
+        Long userId = 1L;
+        UserResponse userResponse =
+                UserResponse.builder().id(userId).email("test@example.com").name("테스트 사용자").build();
+
+        when(userFindService.findById(userId)).thenReturn(userResponse);
+
+        // when & then
+        mockMvc.perform(get("/users/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(userId))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.name").value("테스트 사용자"));
+    }
+
+    @Test
+    void update_shouldReturnOk() throws Exception {
+        // given
+        Long userId = 1L;
+        UserUpdateRequest request =
+                UserUpdateRequest.builder().name("수정된 이름").phone("010-1234-5678").build();
+
+        UserResponse userResponse =
+                UserResponse.builder()
+                        .id(userId)
+                        .email("test@example.com")
+                        .name("수정된 이름")
+                        .phone("010-1234-5678")
+                        .build();
+
+        when(userUpdateService.update(anyLong(), any(UserUpdateRequest.class)))
+                .thenReturn(userResponse);
+
+        // when & then
+        mockMvc.perform(
+                        put("/users/{id}", userId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("수정된 이름"))
+                .andExpect(jsonPath("$.data.phone").value("010-1234-5678"));
+    }
+
+    @Test
+    void delete_shouldReturnOk() throws Exception {
+        // given
+        Long userId = 1L;
+
+        // when & then
+        mockMvc.perform(delete("/users/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("성공적으로 삭제되었습니다."));
+    }
+}

--- a/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
+++ b/services/user-service/src/test/java/com/paystream/user/controller/UserControllerTest.java
@@ -47,7 +47,7 @@ class UserControllerTest {
     @MockBean private UserDeleteService userDeleteService;
 
     @Test
-    void findById_shouldReturnOk() throws Exception {
+    void findByIdShouldReturnOk() throws Exception {
         // given
         Long userId = 1L;
         UserResponse userResponse =
@@ -64,7 +64,7 @@ class UserControllerTest {
     }
 
     @Test
-    void update_shouldReturnOk() throws Exception {
+    void updateShouldReturnOk() throws Exception {
         // given
         Long userId = 1L;
         UserUpdateRequest request =
@@ -92,7 +92,7 @@ class UserControllerTest {
     }
 
     @Test
-    void delete_shouldReturnOk() throws Exception {
+    void deleteShouldReturnOk() throws Exception {
         // given
         Long userId = 1L;
 

--- a/services/user-service/src/test/resources/application-test.yml
+++ b/services/user-service/src/test/resources/application-test.yml
@@ -1,0 +1,43 @@
+spring:
+  application:
+    name: user-service-test
+  profiles:
+    active: test
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+  redis:
+    host: localhost
+    port: 6379
+    timeout: 2000ms
+
+server:
+  port: 0  # 랜덤 포트 사용
+
+eureka:
+  client:
+    enabled: false  # 테스트 시 Eureka 비활성화
+    register-with-eureka: false
+    fetch-registry: false
+
+jwt:
+  secret: test-secret-key-for-jwt-token-generation-in-test-environment-only
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000
+
+logging:
+  level:
+    com.paystream.user: DEBUG
+

--- a/services/user-service/src/test/resources/application-test.yml
+++ b/services/user-service/src/test/resources/application-test.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: user-service-test
-  profiles:
-    active: test
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -18,10 +16,9 @@ spring:
   h2:
     console:
       enabled: true
-  redis:
-    host: localhost
-    port: 6379
-    timeout: 2000ms
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 
 server:
   port: 0  # 랜덤 포트 사용


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- user-service에 테스트 코드 추가
- payment-service에 PayStreamExceptionAdvice를 추가하여 다른 서비스와 일관된 예외 처리 적용
- PayStreamExceptionAdvice에 IllegalArgumentException 핸들러를 추가하여 예외 처리 개선

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- user-service 테스트 코드 추가
  - 테스트 설정 파일 (`application-test.yml`) 추가
  - 애플리케이션 컨텍스트 로드 테스트 (`UserServiceApplicationTests`) 추가
  - PingController 테스트 (`PingControllerTest`) 추가
  - AuthController 테스트 (`AuthControllerTest`) 추가 - 회원가입, 로그인, 토큰 갱신, 로그아웃 테스트 포함
  - UserController 테스트 (`UserControllerTest`) 추가 - 사용자 조회, 수정, 삭제 테스트 포함
  - 테스트 메서드 이름을 카멜 케이스로 변경하여 Checkstyle 규칙 준수
  - `@WebMvcTest`에서 `@SpringBootTest`로 변경하여 전체 컨텍스트 로드
  - `@MockBean`을 `@MockitoBean`으로 변경 (deprecated 대응)
  - `RedisConnectionFactory` 모킹 추가

- payment-service 예외 처리 개선
  - `PayStreamExceptionAdvice` 추가로 전역 예외 처리 적용
  - 다른 서비스(user-service, inventory-service)와 일관된 예외 응답 형식 제공

- PayStreamExceptionAdvice 개선
  - `IllegalArgumentException` 핸들러 추가
  - 모든 `ExceptionHandler`가 `ResponseEntity`를 반환하도록 수정하여 HTTP 상태 코드를 명시적으로 설정
  - 기존: HTTP 상태 코드가 항상 200 OK로 반환되던 문제 해결
  - 수정: 실제 예외에 맞는 HTTP 상태 코드(400, 404 등) 반환

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. user-service 테스트 실행
   ```bash
   ./gradlew :services:user-service:test
   ```
   - 모든 테스트가 통과하는지 확인 (11개 테스트 모두 통과)

2. payment-service 빌드 확인
   ```bash
   ./gradlew :services:payment-service:compileJava
   ```
   - PayStreamExceptionAdvice import가 정상적으로 동작하는지 확인

3. 예외 처리 확인
   - `IllegalArgumentException` 발생 시 HTTP 400 Bad Request 반환 확인
   - 유효성 검사 실패 시 HTTP 400 Bad Request 반환 확인
   - `PayStreamException` 발생 시 적절한 HTTP 상태 코드 반환 확인

4. 애플리케이션 실행 확인
   - user-service와 payment-service가 정상적으로 시작되는지 확인
   - 각 엔드포인트가 정상적으로 동작하는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 모든 테스트 통과
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- user-service 테스트는 `@SpringBootTest`와 `@AutoConfigureMockMvc`를 사용하여 전체 애플리케이션 컨텍스트를 로드합니다
- `@MockitoBean`을 사용하여 필요한 빈들을 모킹합니다
- `PayStreamExceptionAdvice`가 이제 `ResponseEntity`를 반환하여 HTTP 상태 코드를 명시적으로 설정합니다
  - 기존에는 응답 본문에만 상태 정보가 포함되고 HTTP 상태 코드는 항상 200이었습니다
  - 이제 실제 예외에 맞는 HTTP 상태 코드가 반환되어 REST API 표준을 준수합니다
- `IllegalArgumentException`도 이제 HTTP 400 Bad Request로 처리됩니다

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->

Ref: #