### PR TITLE
feat(notification): API DTO 추가 및 로컬DB Swagger 의존성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,6 +254,7 @@ gradle-app.setting
 *.hprof
 
 ### Environment Variables ###
+# .env 파일 (비밀 정보 포함 가능)
 .env
 .env.local
 .env.*.local

--- a/services/notification-service/build.gradle
+++ b/services/notification-service/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     // Actuator - 헬스 체크 및 모니터링
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     
+    // Swagger - API 문서화
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    
     // Kafka - 이벤트 기반 알림 수신 (추후 활성화)
     // implementation 'org.springframework.kafka:spring-kafka'
     

--- a/services/notification-service/build.gradle
+++ b/services/notification-service/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     // Spring Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     
+    // Validation - DTO 검증을 위한 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    
     // JPA - 엔티티/리포지토리 사용을 위한 의존성
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationRequest.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationRequest.java
@@ -1,0 +1,40 @@
+package com.paystream.notification.dto;
+
+import com.paystream.notification.domain.NotificationChannel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 알림 생성 요청 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationRequest {
+
+    // 수신 사용자 식별자
+    @NotNull(message = "사용자 ID는 필수입니다")
+    private Long userId;
+
+    // 알림 채널
+    @NotNull(message = "알림 채널은 필수입니다")
+    private NotificationChannel channel;
+
+    // 알림 제목
+    @NotBlank(message = "알림 제목은 필수입니다")
+    private String title;
+
+    // 알림 본문
+    @NotBlank(message = "알림 본문은 필수입니다")
+    private String body;
+
+    // 예약 전송 시각 (선택, null이면 즉시 전송)
+    private LocalDateTime scheduledAt;
+
+    // 템플릿 코드 (선택)
+    private String templateCode;
+}

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationResponse.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationResponse.java
@@ -1,0 +1,53 @@
+package com.paystream.notification.dto;
+
+import com.paystream.notification.domain.NotificationChannel;
+import com.paystream.notification.domain.NotificationStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 알림 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+
+    // 알림 ID
+    private Long id;
+
+    // 수신 사용자 식별자
+    private Long userId;
+
+    // 알림 채널
+    private NotificationChannel channel;
+
+    // 알림 제목
+    private String title;
+
+    // 알림 본문
+    private String body;
+
+    // 알림 상태
+    private NotificationStatus status;
+
+    // 예약 전송 시각
+    private LocalDateTime scheduledAt;
+
+    // 실제 전송 시각
+    private LocalDateTime sentAt;
+
+    // 재시도 횟수
+    private int retryCount;
+
+    // 템플릿 코드
+    private String templateCode;
+
+    // 생성 시각
+    private LocalDateTime createdAt;
+
+    // 수정 시각
+    private LocalDateTime updatedAt;
+}

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationTemplateRequest.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationTemplateRequest.java
@@ -1,0 +1,34 @@
+package com.paystream.notification.dto;
+
+import com.paystream.notification.domain.NotificationChannel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 알림 템플릿 생성/수정 요청 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationTemplateRequest {
+
+    // 템플릿 식별 코드
+    @NotBlank(message = "템플릿 코드는 필수입니다")
+    private String code;
+
+    // 알림 채널
+    @NotNull(message = "알림 채널은 필수입니다")
+    private NotificationChannel channel;
+
+    // 로케일 (예: ko_KR)
+    private String locale;
+
+    // 제목 템플릿
+    private String titleTemplate;
+
+    // 본문 템플릿
+    private String bodyTemplate;
+}

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationTemplateResponse.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationTemplateResponse.java
@@ -1,0 +1,40 @@
+package com.paystream.notification.dto;
+
+import com.paystream.notification.domain.NotificationChannel;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 알림 템플릿 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationTemplateResponse {
+
+    // 템플릿 ID
+    private Long id;
+
+    // 템플릿 식별 코드
+    private String code;
+
+    // 알림 채널
+    private NotificationChannel channel;
+
+    // 로케일
+    private String locale;
+
+    // 제목 템플릿
+    private String titleTemplate;
+
+    // 본문 템플릿
+    private String bodyTemplate;
+
+    // 생성 시각
+    private LocalDateTime createdAt;
+
+    // 수정 시각
+    private LocalDateTime updatedAt;
+}

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationUpdateRequest.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/NotificationUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.paystream.notification.dto;
+
+import com.paystream.notification.domain.NotificationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 알림 업데이트 요청 DTO (읽음 처리 등) */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationUpdateRequest {
+
+    // 알림 상태 변경 (예: READ로 변경하여 읽음 처리)
+    private NotificationStatus status;
+}

--- a/services/notification-service/src/main/java/com/paystream/notification/dto/UnreadCountResponse.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,20 @@
+package com.paystream.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 읽지 않은 알림 개수 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnreadCountResponse {
+
+    // 사용자 ID
+    private Long userId;
+
+    // 읽지 않은 알림 개수
+    private long unreadCount;
+}

--- a/services/notification-service/src/main/resources/application-local.yml
+++ b/services/notification-service/src/main/resources/application-local.yml
@@ -1,0 +1,29 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  # H2 데이터베이스 설정 (로컬 개발용)
+  datasource:
+    url: jdbc:h2:mem:notificationdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # JPA/Hibernate 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop # 개발 환경에서는 자동으로 테이블 생성/삭제
+    show-sql: true # SQL 로그 출력
+    properties:
+      hibernate:
+        format_sql: true # SQL 포맷팅
+
+logging:
+  level:
+    root: INFO
+    com.paystream.notification: DEBUG
+    org.springframework.cloud: DEBUG
+    org.springframework.web: DEBUG
+    org.hibernate.type.descriptor.sql: DEBUG # JPA SQL 로그
+

--- a/services/notification-service/src/main/resources/application.yml
+++ b/services/notification-service/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: notification-service
+  profiles:
+    active: local # 기본 실행 프로필 (application-local.yml 불러옴)
 
 # Eureka Client 설정
 eureka:


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- notification-service에 DTO 추가, 로컬 개발용 DB 설정, Swagger 의존성 추가, .env Git 무시 설정 반영

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 알림/템플릿 DTO 6종 추가 (NotificationRequest/Response/Update/UnreadCount, NotificationTemplateRequest/Response)
- SpringDoc OpenAPI 2.8.9 의존성 추가 (notification-service)
- 로컬 개발용 H2 설정 및 기본 프로필 활성화 (`application-local.yml`, `application.yml`)
- .gitignore에 `.env` 계열 파일 추가


## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. `./gradlew :services:notification-service:test` 실행
2. `./gradlew :services:notification-service:compileJava` 실행 (의존성/설정 확인)
3. 필요 시 전체 테스트 `./gradlew clean test`

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- `.env`는 루트에 두되 Git에 커밋하지 않음 (.gitignore 추가 완료)
- notification-service 로컬 실행 시 기본 프로필 `local`로 H2 사용

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #