### PR TITLE
재고 선점 기능 추가 및 재고 감소/증가 쿼리 개선

### DIFF
--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -32,6 +32,7 @@ public enum ExceptionEnum {
     INVALID_DATE_RANGE("I0011", HttpStatus.BAD_REQUEST, "체크인 날짜와 체크아웃 날짜가 바뀌었습니다. 다시 확인해주세요."),
     OUT_OF_BOOKING_PERIOD("I0012", HttpStatus.BAD_REQUEST, "현재 예약 가능 기간이 아닙니다."),
     INSUFFICIENT_STOCK("I0013", HttpStatus.CONFLICT, "재고가 부족한 날짜가 있습니다. 다시 확인해주세요."),
+    OVER_STOCK_FLOW("I0013", HttpStatus.CONFLICT, "저장 가능한 최대 수량을 초과하였습니다."),
     ALREADY_RESERVED_BY_USER("I0014", HttpStatus.BAD_REQUEST, "이미 해당 사용자가 선점(예약 시도) 중인 상품입니다."),
     RESERVATION_EXPIRED("I0015", HttpStatus.BAD_REQUEST, "유휴시간을 초과했습니다."),
 

--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -32,7 +32,8 @@ public enum ExceptionEnum {
     INVALID_DATE_RANGE("I0011", HttpStatus.BAD_REQUEST, "체크인 날짜와 체크아웃 날짜가 바뀌었습니다. 다시 확인해주세요."),
     OUT_OF_BOOKING_PERIOD("I0012", HttpStatus.BAD_REQUEST, "현재 예약 가능 기간이 아닙니다."),
     INSUFFICIENT_STOCK("I0013", HttpStatus.CONFLICT, "재고가 부족한 날짜가 있습니다. 다시 확인해주세요."),
-    INVALID_STOCK_CANCEL_REQUEST("I0014", HttpStatus.BAD_REQUEST, "재고 정보가 올바르지 않아 취소할 수 없습니다."),
+    ALREADY_RESERVED_BY_USER("I0014", HttpStatus.BAD_REQUEST, "이미 해당 사용자가 선점(예약 시도) 중인 상품입니다."),
+    RESERVATION_EXPIRED("I0015", HttpStatus.BAD_REQUEST, "유휴시간을 초과했습니다."),
 
     // user-service -> U0001
     USER_NOT_FOUND("U0001", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/entity/DailyInventory.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/entity/DailyInventory.java
@@ -32,12 +32,13 @@ public class DailyInventory {
 
     private int stockAvailable; // 가용 재고
 
-    public void increaseStockAvailable() {
-        if (this.stockAvailable >= product.getBaseStock()) {
-            throw new IllegalStateException("상품의 기본 재고보다 많습니다.");
-        }
-
-        this.stockAvailable++;
+    /**
+     * 기본재고보다 많거나 같을 시 false
+     *
+     * @return boolean
+     */
+    public boolean isStockBelowBase() {
+        return this.stockAvailable < product.getBaseStock();
     }
 
     public void decreaseStockAvailable() {

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepository.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepository.java
@@ -1,0 +1,10 @@
+package com.paystream.inventory.inventory.repository;
+
+import java.time.LocalDate;
+
+public interface InventoryQueryDslRepository {
+
+    long inventoriesDecreaseBulk(Long productId, LocalDate checkInDate, LocalDate checkOutDate);
+
+    long inventoriesIncreaseBulk(Long productId, LocalDate checkInDate, LocalDate checkOutDate);
+}

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepositoryImpl.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.paystream.inventory.inventory.repository;
+
+import static com.paystream.inventory.inventory.entity.QDailyInventory.dailyInventory;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class InventoryQueryDslRepositoryImpl implements InventoryQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public long inventoriesDecreaseBulk(
+            Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        return jpaQueryFactory
+                .update(dailyInventory)
+                .set(
+                        dailyInventory.stockAvailable,
+                        dailyInventory.stockAvailable.subtract(1)) // subtract: 빼기 연산
+                .where(
+                        dailyInventory
+                                .product
+                                .id
+                                .eq(productId)
+                                .and(dailyInventory.date.goe(checkInDate))
+                                .and(dailyInventory.date.lt(checkOutDate))
+                                .and(dailyInventory.stockAvailable.gt(0)))
+                .execute();
+    }
+
+    @Override
+    public long inventoriesIncreaseBulk(
+            Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        return jpaQueryFactory
+                .update(dailyInventory)
+                .set(
+                        dailyInventory.stockAvailable,
+                        dailyInventory.stockAvailable.add(1)) // subtract: 빼기 연산
+                .where(
+                        dailyInventory
+                                .product
+                                .id
+                                .eq(productId)
+                                .and(dailyInventory.date.goe(checkInDate))
+                                .and(dailyInventory.date.lt(checkOutDate))
+                                .and(dailyInventory.stockAvailable.gt(0)))
+                .execute();
+    }
+}

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepositoryImpl.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/repository/InventoryQueryDslRepositoryImpl.java
@@ -39,7 +39,7 @@ public class InventoryQueryDslRepositoryImpl implements InventoryQueryDslReposit
                 .update(dailyInventory)
                 .set(
                         dailyInventory.stockAvailable,
-                        dailyInventory.stockAvailable.add(1)) // subtract: 빼기 연산
+                        dailyInventory.stockAvailable.add(1)) // add: 더하기 연산
                 .where(
                         dailyInventory
                                 .product

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
@@ -6,27 +6,72 @@ import com.paystream.core.exception.PayStreamException;
 import com.paystream.inventory.annotation.DistributedLock;
 import com.paystream.inventory.inventory.entity.DailyInventory;
 import com.paystream.inventory.inventory.repository.DailyInventoryRepository;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+/**
+ * 분산락 정리
+ *
+ * <p>분산 락은 트랜잭션을 잘 써야한다. 락 획득 및 반납은 트랜잭션 바깥에서 진행되어야 하고, 비즈니스 로직은 트랜잭션 내에서 동작해야 한다. 이유는 비즈니스 로직이 수행
+ * 된 후 트랜잭션이 종료되지 않고 락을 반납하게 되면 다음 요청이 락을 획득하게 되는데, 이전 작업이 커밋되지 않았기 때문에 데이터 갱신 오류가 발생하게 되면서 데이터 정합성이
+ * 깨질 수 있다. 따라서 비즈니스 로직이 커밋까지 완료된 후 락을 반납해야 이러한 문제가 발생하지 않는다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StockManagerService {
 
     private final DailyInventoryRepository dailyInventoryRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     /**
-     * 분산락 정리
+     * 재고 선점
      *
-     * <p>분산 락은 트랜잭션을 잘 써야한다. 락 획득 및 반납은 트랜잭션 바깥에서 진행되어야 하고, 비즈니스 로직은 트랜잭션 내에서 동작해야 한다. 이유는 비즈니스 로직이
-     * 수행 된 후 트랜잭션이 종료되지 않고 락을 반납하게 되면 다음 요청이 락을 획득하게 되는데, 이전 작업이 커밋되지 않았기 때문에 데이터 갱신 오류가 발생하게 되면서
-     * 데이터 정합성이 깨질 수 있다. 따라서 비즈니스 로직이 커밋까지 완료된 후 락을 반납해야 이러한 문제가 발생하지 않는다.
+     * @param userId 유저ID
+     * @param productId 상품ID (숙소)
      */
+    @DistributedLock(key = "'lock:inventory:' + #productId")
+    public void reserveStock(
+            String userId, Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        // 날짜 역전 확인
+        if (checkInDate.isAfter(checkOutDate)) {
+            throw new PayStreamException(INVALID_DATE_RANGE);
+        }
+
+        // 재고 조회
+        List<DailyInventory> inventoryList =
+                dailyInventoryRepository.findInventoriesByDateRange(
+                        productId, checkInDate, checkOutDate);
+
+        // 재고 일수 확인
+        validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
+
+        // 모든 날짜에 재고가 있는지 확인
+        boolean isStockAvailable =
+                inventoryList.stream().allMatch(DailyInventory::isStockAvailable);
+
+        if (inventoryList.isEmpty() || !isStockAvailable) {
+            throw new PayStreamException(INSUFFICIENT_STOCK);
+        }
+
+        // 선점 캐시 기록 (10분 TTL)
+        String reserveKey = "reserve:prod:" + productId + ":user:" + userId;
+        Boolean isPending =
+                redisTemplate
+                        .opsForValue()
+                        .setIfAbsent(reserveKey, "PENDING", Duration.ofMinutes(10));
+
+        // 중복 선점 방지
+        if (Boolean.FALSE.equals(isPending)) {
+            throw new PayStreamException(ALREADY_RESERVED_BY_USER);
+        }
+    }
 
     /**
      * 숙소 예약이 들어오면 해당 상품의 재고를 감소 시킨다.
@@ -42,20 +87,13 @@ public class StockManagerService {
             throw new PayStreamException(INVALID_DATE_RANGE);
         }
 
+        // 재고 조회
         List<DailyInventory> inventoryList =
                 dailyInventoryRepository.findInventoriesByDateRange(
                         productId, checkInDate, checkOutDate);
 
-        // 조회된 일수와 기대 일수 확인
-        long expectedDays = ChronoUnit.DAYS.between(checkInDate, checkOutDate);
-        if (expectedDays != inventoryList.size()) {
-            log.error(
-                    "재고 데이터 불일치: 상품ID={}, 기대일수={}, 조회된일수={}",
-                    productId,
-                    expectedDays,
-                    inventoryList.size());
-            throw new PayStreamException(OUT_OF_BOOKING_PERIOD);
-        }
+        // 재고 일수 확인
+        validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
 
         // 모든 날짜에 재고가 있는지 확인
         boolean isStockAvailable =
@@ -78,15 +116,38 @@ public class StockManagerService {
      */
     @DistributedLock(key = "'lock:inventory:' + #productId")
     public void increaseStock(Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        // 날짜 역전 확인
+        if (checkInDate.isAfter(checkOutDate)) {
+            throw new PayStreamException(INVALID_DATE_RANGE);
+        }
+
+        // 재고 조회
         List<DailyInventory> inventoryList =
                 dailyInventoryRepository.findInventoriesByDateRange(
                         productId, checkInDate, checkOutDate);
 
+        // 재고 일수 확인
+        validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
+
+        // 재고 증가
+        inventoryList.forEach(DailyInventory::increaseStockAvailable);
+    }
+
+    // 재고 일수 검증
+    private void validateBookingPeriod(
+            Long productId,
+            LocalDate checkInDate,
+            LocalDate checkOutDate,
+            List<DailyInventory> inventoryList) {
+        // 조회된 일수와 기대 일수 확인
         long expectedDays = ChronoUnit.DAYS.between(checkInDate, checkOutDate);
         if (expectedDays != inventoryList.size()) {
-            throw new PayStreamException(INVALID_STOCK_CANCEL_REQUEST);
+            log.error(
+                    "재고 데이터 불일치: 상품ID={}, 기대일수={}, 조회된일수={}",
+                    productId,
+                    expectedDays,
+                    inventoryList.size());
+            throw new PayStreamException(OUT_OF_BOOKING_PERIOD);
         }
-
-        inventoryList.forEach(DailyInventory::increaseStockAvailable);
     }
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
@@ -114,6 +114,14 @@ public class StockManagerService {
                 checkInDate,
                 checkOutDate,
                 inventoryList -> {
+                    boolean isStockBelowBase =
+                            inventoryList.stream().allMatch(DailyInventory::isStockBelowBase);
+
+                    // 기본 수량보다 많거나 같은 날짜가 있다면 예외를 발생
+                    if (!isStockBelowBase) {
+                        throw new PayStreamException(OVER_STOCK_FLOW);
+                    }
+
                     // 재고 증가
                     inventoryQueryDslRepository.inventoriesIncreaseBulk(
                             productId, checkInDate, checkOutDate);

--- a/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/inventory/service/StockManagerService.java
@@ -6,10 +6,12 @@ import com.paystream.core.exception.PayStreamException;
 import com.paystream.inventory.annotation.DistributedLock;
 import com.paystream.inventory.inventory.entity.DailyInventory;
 import com.paystream.inventory.inventory.repository.DailyInventoryRepository;
+import com.paystream.inventory.inventory.repository.InventoryQueryDslRepository;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class StockManagerService {
 
     private final DailyInventoryRepository dailyInventoryRepository;
+    private final InventoryQueryDslRepository inventoryQueryDslRepository;
     private final RedisTemplate<String, String> redisTemplate;
 
     /**
@@ -39,38 +42,32 @@ public class StockManagerService {
     @DistributedLock(key = "'lock:inventory:' + #productId")
     public void reserveStock(
             String userId, Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
-        // 날짜 역전 확인
-        if (checkInDate.isAfter(checkOutDate)) {
-            throw new PayStreamException(INVALID_DATE_RANGE);
-        }
 
-        // 재고 조회
-        List<DailyInventory> inventoryList =
-                dailyInventoryRepository.findInventoriesByDateRange(
-                        productId, checkInDate, checkOutDate);
+        executeWithInventory(
+                productId,
+                checkInDate,
+                checkOutDate,
+                inventoryList -> {
+                    // 모든 날짜에 재고가 있는지 확인
+                    boolean isStockAvailable =
+                            inventoryList.stream().allMatch(DailyInventory::isStockAvailable);
 
-        // 재고 일수 확인
-        validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
+                    if (inventoryList.isEmpty() || !isStockAvailable) {
+                        throw new PayStreamException(INSUFFICIENT_STOCK);
+                    }
 
-        // 모든 날짜에 재고가 있는지 확인
-        boolean isStockAvailable =
-                inventoryList.stream().allMatch(DailyInventory::isStockAvailable);
+                    // 선점 캐시 기록 (10분 TTL)
+                    String reserveKey = "reserve:prod:" + productId + ":user:" + userId;
+                    Boolean isPending =
+                            redisTemplate
+                                    .opsForValue()
+                                    .setIfAbsent(reserveKey, "PENDING", Duration.ofMinutes(10));
 
-        if (inventoryList.isEmpty() || !isStockAvailable) {
-            throw new PayStreamException(INSUFFICIENT_STOCK);
-        }
-
-        // 선점 캐시 기록 (10분 TTL)
-        String reserveKey = "reserve:prod:" + productId + ":user:" + userId;
-        Boolean isPending =
-                redisTemplate
-                        .opsForValue()
-                        .setIfAbsent(reserveKey, "PENDING", Duration.ofMinutes(10));
-
-        // 중복 선점 방지
-        if (Boolean.FALSE.equals(isPending)) {
-            throw new PayStreamException(ALREADY_RESERVED_BY_USER);
-        }
+                    // 중복 선점 방지
+                    if (Boolean.FALSE.equals(isPending)) {
+                        throw new PayStreamException(ALREADY_RESERVED_BY_USER);
+                    }
+                });
     }
 
     /**
@@ -82,29 +79,25 @@ public class StockManagerService {
      */
     @DistributedLock(key = "'lock:inventory:' + #productId")
     public void decreaseStock(Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
-        // 날짜 역전 확인
-        if (checkInDate.isAfter(checkOutDate)) {
-            throw new PayStreamException(INVALID_DATE_RANGE);
-        }
+        executeWithInventory(
+                productId,
+                checkInDate,
+                checkOutDate,
+                inventoryList -> {
+                    // 모든 날짜에 재고가 있는지 확인
+                    boolean isStockAvailable =
+                            inventoryList.stream().allMatch(DailyInventory::isStockAvailable);
 
-        // 재고 조회
-        List<DailyInventory> inventoryList =
-                dailyInventoryRepository.findInventoriesByDateRange(
-                        productId, checkInDate, checkOutDate);
+                    // 재고 감소
+                    if (inventoryList.isEmpty() || !isStockAvailable) {
+                        throw new PayStreamException(INSUFFICIENT_STOCK);
+                    }
 
-        // 재고 일수 확인
-        validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
-
-        // 모든 날짜에 재고가 있는지 확인
-        boolean isStockAvailable =
-                inventoryList.stream().allMatch(DailyInventory::isStockAvailable);
-
-        // 재고 감소
-        if (inventoryList.isEmpty() || !isStockAvailable) {
-            throw new PayStreamException(INSUFFICIENT_STOCK);
-        }
-
-        inventoryList.forEach(DailyInventory::decreaseStockAvailable);
+                    // 재고 감소 진행
+                    //            inventoryList.forEach(DailyInventory::decreaseStockAvailable);
+                    inventoryQueryDslRepository.inventoriesDecreaseBulk(
+                            productId, checkInDate, checkOutDate);
+                });
     }
 
     /**
@@ -116,6 +109,23 @@ public class StockManagerService {
      */
     @DistributedLock(key = "'lock:inventory:' + #productId")
     public void increaseStock(Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        executeWithInventory(
+                productId,
+                checkInDate,
+                checkOutDate,
+                inventoryList -> {
+                    // 재고 증가
+                    inventoryQueryDslRepository.inventoriesIncreaseBulk(
+                            productId, checkInDate, checkOutDate);
+                });
+    }
+
+    // 공통 실행 템플릿 메소드
+    private void executeWithInventory(
+            Long productId,
+            LocalDate checkInDate,
+            LocalDate checkOutDate,
+            Consumer<List<DailyInventory>> action) {
         // 날짜 역전 확인
         if (checkInDate.isAfter(checkOutDate)) {
             throw new PayStreamException(INVALID_DATE_RANGE);
@@ -129,11 +139,18 @@ public class StockManagerService {
         // 재고 일수 확인
         validateBookingPeriod(productId, checkInDate, checkOutDate, inventoryList);
 
-        // 재고 증가
-        inventoryList.forEach(DailyInventory::increaseStockAvailable);
+        // 재고 부족시 예외 발생
+        if (inventoryList.isEmpty()) {
+            throw new PayStreamException(INSUFFICIENT_STOCK);
+        }
+
+        action.accept(inventoryList);
     }
 
-    // 재고 일수 검증
+    /**
+     * 예약 기간 내 모든 날짜의 재고 데이터 존재 여부 검증 체크인~체크아웃 사이의 '박수(night)'와 실제 DB에서 조회된 '재고 레코드 개수'가 일치하지 않으면,
+     * 일부 날짜에 재고 설정이 누락된 것으로 간주하고 예외를 발생
+     */
     private void validateBookingPeriod(
             Long productId,
             LocalDate checkInDate,

--- a/services/inventory-service/src/main/java/com/paystream/inventory/kafka/StockAction.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/kafka/StockAction.java
@@ -1,8 +1,8 @@
 package com.paystream.inventory.kafka;
 
-import java.time.LocalDate;
+import com.paystream.inventory.kafka.dto.InventoryEvent;
 
 @FunctionalInterface
 public interface StockAction {
-    void execute(Long productId, LocalDate checkInDate, LocalDate checkOutDate);
+    void execute(InventoryEvent event);
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/kafka/config/KafkaConfig.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/kafka/config/KafkaConfig.java
@@ -5,17 +5,32 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
+import org.springframework.util.backoff.FixedBackOff;
 
 @Configuration
 @EnableKafka
 public class KafkaConfig {
+
+    @Bean
+    public DefaultErrorHandler errorHandler() {
+        // 첫번째 인자: 재시도 간격(ms), 두번째 인자: 최대 재시도 횟수
+        FixedBackOff backOff = new FixedBackOff(1000L, 2); // 3번 실행
+        DefaultErrorHandler handler = new DefaultErrorHandler(backOff);
+
+        // 로그 출력 옵션 (선택사항: 재시도 마다 로그를 남길지 설정)
+        handler.setLogLevel(KafkaException.Level.WARN);
+
+        return handler;
+    }
 
     /**
      * Kafka 메시지 리스너 컨테이너를 생성하는 팩토리 빈입니다. @KafkaListener 어노테이션이 붙은 메서드들을 관리하며, 다중 스레드(Concurrency)

--- a/services/inventory-service/src/main/java/com/paystream/inventory/kafka/consumer/OrderConsumer.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/kafka/consumer/OrderConsumer.java
@@ -1,10 +1,14 @@
 package com.paystream.inventory.kafka.consumer;
 
+import static com.paystream.core.exception.ExceptionEnum.RESERVATION_EXPIRED;
+
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.inventory.inventory.service.StockManagerService;
 import com.paystream.inventory.kafka.StockAction;
 import com.paystream.inventory.kafka.dto.InventoryEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +17,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderConsumer {
 
+    private static final String RESERVE_KEY = "reserve:prod:";
+    private static final String STOCK_RESERVE = "order.inventory.reserve";
+    private static final String STOCK_DECREASE = "order.inventory.decrease";
+    private static final String STOCK_INCREASE = "order.inventory.increase";
     private final StockManagerService stockManagerService;
+    private final RedisTemplate<String, String> redisTemplate;
 
     /**
      * 공통 로직을 담은 템플릿 메서드
@@ -34,14 +43,13 @@ public class OrderConsumer {
             long startTime = System.currentTimeMillis();
 
             // 비즈니스 로직
-            stockAction.execute(
-                    event.getProductId(), event.getCheckInDate(), event.getCheckOutDate());
+            stockAction.execute(event);
 
             long endTime = System.currentTimeMillis();
 
             // 완료 로그 (소요 시간 포함)
             log.info(
-                    "[Kafka Consumer] Success: ProductId: {} stock decreased. ({}ms)",
+                    "[Kafka Consumer] Success: ProductId: {} duration ({}ms)",
                     event.getProductId(),
                     (endTime - startTime));
         } catch (Exception e) {
@@ -54,15 +62,54 @@ public class OrderConsumer {
         }
     }
 
-    /** 주문 토픽으로부터 메시지를 수신하여 처리, 재고 감소 로직 수행 @Param message 수신된 주문 메시지 */
-    @KafkaListener(topics = "order.inventory.decrease", groupId = "inventory-group")
-    public void consumeOrderDecreaseInventory(InventoryEvent event) {
-        executeWithLogging("order.inventory.decrease", event, stockManagerService::decreaseStock);
+    /** 주문 토픽으로부터 메시지를 수신, 재고 선점 로직 수행 */
+    @KafkaListener(topics = STOCK_RESERVE, groupId = "inventory-group")
+    public void consumeOrderReserveInventory(InventoryEvent event) {
+        executeWithLogging(
+                STOCK_RESERVE,
+                event,
+                (e) -> {
+                    stockManagerService.reserveStock(
+                            e.getUserId(),
+                            e.getProductId(),
+                            e.getCheckInDate(),
+                            e.getCheckOutDate());
+                });
     }
 
-    /** 주문 토픽으로부터 메시지를 수신하여 처리, 재고 증가 로직 수행 @Param message 수신된 주문 메시지 */
-    @KafkaListener(topics = "order.inventory.increase", groupId = "inventory-group")
+    /** 주문 토픽으로부터 메시지를 수신하여 처리, 재고 감소 로직 수행 */
+    @KafkaListener(topics = STOCK_DECREASE, groupId = "inventory-group")
+    public void consumeOrderDecreaseInventory(InventoryEvent event) {
+        executeWithLogging(
+                STOCK_DECREASE,
+                event,
+                (e) -> {
+                    validateReserve(e);
+                    stockManagerService.decreaseStock(
+                            e.getProductId(), e.getCheckInDate(), e.getCheckOutDate());
+                });
+    }
+
+    /** 주문 토픽으로부터 메시지를 수신하여 처리, 재고 증가 로직 수행 */
+    @KafkaListener(topics = STOCK_INCREASE, groupId = "inventory-group")
     public void consumeOrderIncreaseInventory(InventoryEvent event) {
-        executeWithLogging("order.inventory.increase", event, stockManagerService::increaseStock);
+        executeWithLogging(
+                STOCK_INCREASE,
+                event,
+                (e) -> {
+                    validateReserve(e);
+                    stockManagerService.increaseStock(
+                            e.getProductId(), e.getCheckInDate(), e.getCheckOutDate());
+                });
+    }
+
+    // 재고 선점 여부 확인
+    private void validateReserve(InventoryEvent e) {
+        String reserveKey = RESERVE_KEY + e.getProductId() + ":user:" + e.getUserId();
+        Boolean isReserved = redisTemplate.hasKey(reserveKey);
+
+        if (!isReserved) {
+            throw new PayStreamException(RESERVATION_EXPIRED);
+        }
     }
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/kafka/dto/InventoryEvent.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/kafka/dto/InventoryEvent.java
@@ -12,7 +12,8 @@ import lombok.ToString;
 @AllArgsConstructor
 public class InventoryEvent {
 
-    Long productId;
-    LocalDate checkInDate;
-    LocalDate checkOutDate;
+    private String userId;
+    private Long productId;
+    private LocalDate checkInDate;
+    private LocalDate checkOutDate;
 }

--- a/services/inventory-service/src/main/resources/application-local.yml
+++ b/services/inventory-service/src/main/resources/application-local.yml
@@ -26,9 +26,14 @@ spring:
         highlight_sql: true
         default_batch_fetch_size: 1000
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        jdbc.batch_size: 50           # 한 번에 모아서 보낼 쿼리 개수
-        order_inserts: true           # insert 문 정렬하여 배치 효율 최적화
-        order_updates: true           # update 문 정렬
+        generate_statistics: true # 실행 후 하단에 통계 요약이 출력됨
+        jdbc:
+          batch_size: 50           # 한 번에 모아서 보낼 쿼리 개수
+          order_inserts: true           # insert 문 정렬하여 배치 효율 최적화
+          order_updates: true           # update 문 정렬
+    logging:
+      level:
+        org.hibernate.engine.jdbc.batch.internal.BatchingBatch: DEBUG # 배치 상세 로그
   # Redis 설정
   data:
     redis:

--- a/services/inventory-service/src/test/java/com/paystream/inventory/inventory/service/StockManagerServiceTest.java
+++ b/services/inventory-service/src/test/java/com/paystream/inventory/inventory/service/StockManagerServiceTest.java
@@ -227,6 +227,7 @@ class StockManagerServiceTest {
                 dailyInventoryRepository.findInventoriesByDateRange(
                         productId, CHECK_IN_DATE, CHECK_OUT_DATE);
         findInventories.forEach(DailyInventory::decreaseStockAvailable);
+        dailyInventoryRepository.flush(); // 수정된 재고를 커밋
 
         int threadCount = 5; // 동시에 들어오는 인원수
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);

--- a/services/inventory-service/src/test/java/com/paystream/inventory/inventory/service/StockManagerServiceTest.java
+++ b/services/inventory-service/src/test/java/com/paystream/inventory/inventory/service/StockManagerServiceTest.java
@@ -190,7 +190,7 @@ class StockManagerServiceTest {
 
     @DisplayName("다른 쓰레드가 이미 락을 점유하고 있으면 락 획득 실패 예외가 발생한다.")
     @Test
-    void throwExceptionWhenLockAcquisitionFails() {
+    void throwExceptionWhenLockAcquisitionFails() throws InterruptedException {
         // given
         String lockKey = "lock:inventory:" + productId;
         RLock rLock = redissonClient.getLock(lockKey);
@@ -210,6 +210,9 @@ class StockManagerServiceTest {
                             }
                         });
         lockPreemptor.start();
+
+        // 다른 쓰레드가 락을 획득할 수 있도록 잠시 대기
+        Thread.sleep(1000);
 
         // then
         assertThatThrownBy(


### PR DESCRIPTION
## 📌 PR 개요
- 상품 선택 -> 주문 -> 재고선점 -> 결제 순으로 진행되며, 고객이 주문 단계로 접근시 해당 유저에게 상품의 재고를 선점
- 10분간 결제가 발생하지 않으면 선점 캐시 자동 소멸
- 10분 이내에 결제 발생시 재고 감소/증가 로직에서 해당 캐시 여부를 확인 후 재고를 감소/증가 로직을 진행

## 🔍 변경 사항
- topic및 key 설정
    - 재고 선점 topic(order.inventory.reserve)
    - 재고 선점 캐시 key(reserve:prod:{productId):user:{userId} (선점캐시는 10분간 유지, 10분 이후는 자동소멸)
- 재고 선점 검증시 유휴시간 발생시 예외 발생 (``RESERVATION_EXPIRED``: `유휴시간을 초과했습니다.`)
- 재고 선점을 중복으로 발생시 예외 발생 (`ALREADY_RESERVED_BY_USER`: `이미 해당 사용자가 선점(예약 시도) 중인 상품입니다.`)
- 재고 감소/증가 쿼리 개선

## 🧪 테스트 방법
1. kafka topic : `order.inventory.reserve`과 value 설정
    - 테스트 데이터: `{ "userId": "1", "productId": "1", "checkInDate": "2026-02-28", "checkOutDate": "2026-03-10" }`
2. 레디스의 `keys *`또는 `scan 0`을 통해 `"reserve:prod:1:user:1"`을 확인 -> 성공
3. 유휴시간 확인: `ttl reserve:prod:1:user:1`을 통해 남은 시간 확인
4. 재고선점을 진행 후 재고 감소/증가 topic 요청 -> 선점캐시 있을 시 성공, 없을 시 예외

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
-

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #