### PR TITLE
fix(ci): Validate Gradle Wrapper 단계 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -106,9 +103,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -134,9 +128,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -176,9 +167,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -204,9 +192,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -234,9 +219,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -263,9 +245,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -291,9 +270,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- CI에서 Validate Gradle Wrapper 단계 제거로, 외부 네트워크(ETIMEDOUT/ENETUNREACH)로 인한 job 실패를 막고 CI 안정화

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `.github/workflows/ci.yml`: 모든 build job에서 **Validate Gradle Wrapper** 단계(`gradle/actions/wrapper-validation@v3`) 제거
  - 적용 job: build-common-core, build-api-gateway, build-eureka-server, build-inventory-service, build-notification-service, build-order-service, build-payment-service, build-user-service (총 8개)
- 해당 단계는 Gradle Wrapper 체크섬 검증용이며, 제거해도 `./gradlew` 기반 빌드/테스트는 그대로 동작함

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 이 브랜치를 push한 뒤 GitHub Actions에서 CI가 실행되는지 확인
2. 모든 실행된 build job이 Validate Gradle Wrapper 없이 **Set up JDK 17 → Grant execute permission → Lint & Test** 순으로 성공하는지 확인
3. (선택) 로컬에서 `./gradlew build` 등으로 빌드가 정상 동작하는지 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- wrapper-validation은 외부 서버 접속 실패 시 ETIMEDOUT/ENETUNREACH로 job이 실패해 CI가 불안정해져 제거했습니다. Wrapper 변조 검증은 포기하고, 빌드/테스트 성공 여부만 CI에서 확인하는 형태로 유지합니다.

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #