### PR TITLE
feat(order): order-service 주문 API 및 Kafka reserve 연동 구현, gateway/payment/dev-scripts 보완

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
               - 'gradlew*'
               - '.github/workflows/**'
               - 'common/core/**'
-              - 'services/**'
 
   build-common-core:
     name: Build common-core
@@ -93,7 +92,7 @@ jobs:
   build-api-gateway:
     name: Build api-gateway
     needs: detect-changes
-    if: needs.detect-changes.outputs.api_gateway == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.api_gateway == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -119,7 +118,7 @@ jobs:
   build-eureka-server:
     name: Build eureka-server
     needs: detect-changes
-    if: needs.detect-changes.outputs.eureka_server == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.eureka_server == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -145,7 +144,7 @@ jobs:
   build-inventory-service:
     name: Build inventory-service
     needs: detect-changes
-    if: needs.detect-changes.outputs.inventory_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.inventory_service == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
 
     # redis 설정 추가
@@ -183,7 +182,7 @@ jobs:
   build-notification-service:
     name: Build notification-service
     needs: detect-changes
-    if: needs.detect-changes.outputs.notification_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.notification_service == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -209,7 +208,7 @@ jobs:
   build-order-service:
     name: Build order-service
     needs: detect-changes
-    if: needs.detect-changes.outputs.order_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.order_service == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -235,7 +234,7 @@ jobs:
   build-payment-service:
     name: Build payment-service
     needs: detect-changes
-    if: needs.detect-changes.outputs.payment_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.payment_service == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -261,7 +260,7 @@ jobs:
   build-user-service:
     name: Build user-service
     needs: detect-changes
-    if: needs.detect-changes.outputs.user_service == 'true' || needs.detect-changes.outputs.any == 'true'
+    if: needs.detect-changes.outputs.user_service == 'true' || needs.detect-changes.outputs.common_core == 'true' || needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -54,12 +54,27 @@ public enum ExceptionEnum {
     PAYMENT_MERCHANT_UID_MISMATCH("P0004", HttpStatus.BAD_REQUEST, "주문 번호가 일치하지 않습니다."),
     PAYMENT_NOT_PAID("P0005", HttpStatus.BAD_REQUEST, "결제 완료된 건만 취소할 수 있습니다."),
     PAYMENT_PORTONE_ERROR("P0006", HttpStatus.INTERNAL_SERVER_ERROR, "포트원 API 호출 중 오류가 발생했습니다."),
+    PAYMENT_MISSING_AUTH_USER_ID("P0007", HttpStatus.BAD_REQUEST, "인증 사용자 헤더가 누락되었습니다."),
+    PAYMENT_INVALID_AUTH_USER_ID("P0008", HttpStatus.BAD_REQUEST, "인증 사용자 헤더 형식이 올바르지 않습니다."),
+    PAYMENT_PORTONE_API_SECRET_MISSING(
+            "P0009", HttpStatus.INTERNAL_SERVER_ERROR, "포트원 API Secret이 설정되지 않았습니다."),
+    PAYMENT_PORTONE_UNAUTHORIZED("P0010", HttpStatus.UNAUTHORIZED, "포트원 API 인증에 실패했습니다."),
+    PAYMENT_PORTONE_BAD_REQUEST("P0011", HttpStatus.BAD_REQUEST, "포트원 API 요청 형식이 올바르지 않습니다."),
+    PAYMENT_PORTONE_NOT_FOUND("P0012", HttpStatus.NOT_FOUND, "포트원 결제 정보를 찾을 수 없습니다."),
+    PAYMENT_PORTONE_CANCEL_CONFLICT(
+            "P0013", HttpStatus.CONFLICT, "포트원 결제 취소 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
     // order-service -> O0001
     ORDER_NOT_FOUND("O0001", HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다."),
     ORDER_ALREADY_PAID("O0002", HttpStatus.CONFLICT, "이미 결제 완료된 주문입니다."),
     ORDER_ALREADY_CANCELLED("O0003", HttpStatus.CONFLICT, "이미 취소된 주문입니다."),
     ORDER_INVALID_STATUS("O0004", HttpStatus.BAD_REQUEST, "해당 상태에서는 요청할 수 없습니다."),
+    ORDER_MISSING_AUTH_USER_ID("O0005", HttpStatus.BAD_REQUEST, "인증 사용자 헤더가 누락되었습니다."),
+    ORDER_INVALID_AUTH_USER_ID("O0006", HttpStatus.BAD_REQUEST, "인증 사용자 헤더 형식이 올바르지 않습니다."),
+    ORDER_EVENT_PUBLISH_FAILED("O0007", HttpStatus.INTERNAL_SERVER_ERROR, "재고 선점 이벤트 발행에 실패했습니다."),
+
+    USER_MISSING_BEARER_TOKEN("U0007", HttpStatus.BAD_REQUEST, "Authorization 헤더에 Bearer 토큰이 필요합니다."),
+    USER_BLACKLIST_ADD_FAILED("U0008", HttpStatus.INTERNAL_SERVER_ERROR, "블랙리스트 추가에 실패했습니다."),
     ;
 
     private String code;

--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -73,7 +73,8 @@ public enum ExceptionEnum {
     ORDER_INVALID_AUTH_USER_ID("O0006", HttpStatus.BAD_REQUEST, "인증 사용자 헤더 형식이 올바르지 않습니다."),
     ORDER_EVENT_PUBLISH_FAILED("O0007", HttpStatus.INTERNAL_SERVER_ERROR, "재고 선점 이벤트 발행에 실패했습니다."),
 
-    USER_MISSING_BEARER_TOKEN("U0007", HttpStatus.BAD_REQUEST, "Authorization 헤더에 Bearer 토큰이 필요합니다."),
+    USER_MISSING_BEARER_TOKEN(
+            "U0007", HttpStatus.BAD_REQUEST, "Authorization 헤더에 Bearer 토큰이 필요합니다."),
     USER_BLACKLIST_ADD_FAILED("U0008", HttpStatus.INTERNAL_SERVER_ERROR, "블랙리스트 추가에 실패했습니다."),
     ;
 

--- a/dev-scripts/README.md
+++ b/dev-scripts/README.md
@@ -33,6 +33,7 @@ MSA 서비스를 한 번에 실행하고 종료하는 스크립트입니다.
 - **자동 순서 관리**: Eureka Server를 먼저 실행하고, 다른 서비스들이 등록할 수 있도록 대기합니다.
 - **중복 실행 방지**: 이미 실행 중인 서비스는 건너뜁니다.
 - **포트 충돌 확인**: 포트가 이미 사용 중인 경우 해당 서비스를 건너뜁니다.
+- **인프라 자동 실행**: Redis, Kafka, Kafka UI를 Docker Compose로 자동 시작/종료합니다.
 - **로그 관리**: 각 서비스의 로그는 `dev-scripts/pids/*.log`에 저장됩니다.
 - **PID 관리**: 각 서비스의 PID는 `dev-scripts/pids/*.pid`에 저장되어 종료 시 사용됩니다.
 
@@ -42,6 +43,8 @@ MSA 서비스를 한 번에 실행하고 종료하는 스크립트입니다.
 
 - **Eureka Dashboard**: http://localhost:8761
 - **API Gateway**: http://localhost:8000
+- **Kafka Broker**: localhost:29092
+- **Kafka UI**: http://localhost:8080
 
 ## 로그 확인
 

--- a/dev-scripts/start.sh
+++ b/dev-scripts/start.sh
@@ -121,6 +121,8 @@ check_port() {
 REDIS_HOST=${REDIS_HOST:-localhost}
 REDIS_PORT=${REDIS_PORT:-6379}
 REDIS_CONTAINER_NAME="paystream-redis"
+KAFKA_PORT=${KAFKA_PORT:-29092}
+KAFKA_CONTAINER_NAME="paystream-kafka"
 
 # Docker가 실행 중인지 확인하는 함수
 is_docker_running() {
@@ -330,6 +332,53 @@ start_redis() {
     echo -e "${YELLOW}⚠️  Redis 없이 서비스를 계속 실행합니다. (토큰 블랙리스트 기능이 작동하지 않을 수 있습니다)${NC}"
 }
 
+# Kafka 시작 함수
+start_kafka() {
+    echo -e "${GREEN}🔥 Kafka 시작 중...${NC}"
+
+    # 포트가 이미 사용 중이면 기존 인스턴스 사용
+    if check_port "$KAFKA_PORT"; then
+        echo -e "${YELLOW}⚠️  Kafka 포트 $KAFKA_PORT가 이미 사용 중입니다. 기존 인스턴스를 사용합니다.${NC}"
+        return
+    fi
+
+    # Docker가 실행 중이 아니면 자동 시작 시도
+    if ! is_docker_running; then
+        echo -e "${YELLOW}🐳 Docker daemon이 실행 중이 아닙니다. Docker Desktop을 시작합니다...${NC}"
+        if ! start_docker_desktop; then
+            echo -e "${RED}👿 Docker Desktop 시작 실패. Kafka 없이 서비스를 계속 실행합니다.${NC}"
+            echo -e "${YELLOW}💡 수동으로 Docker Desktop을 시작한 후 다시 실행하세요.${NC}"
+            return
+        fi
+    fi
+
+    # Docker Compose로 Kafka 시작
+    if [ -f "$PROJECT_ROOT/docker-compose.yml" ]; then
+        cd "$PROJECT_ROOT"
+        if command -v docker-compose > /dev/null 2>&1; then
+            if docker-compose up -d kafka kafka-ui > /dev/null 2>&1; then
+                sleep 3
+                if check_port "$KAFKA_PORT"; then
+                    echo -e "${GREEN}🐳 Kafka Docker Compose 시작 완료${NC}"
+                    return
+                fi
+            fi
+        elif docker compose version > /dev/null 2>&1; then
+            if docker compose up -d kafka kafka-ui > /dev/null 2>&1; then
+                sleep 3
+                if check_port "$KAFKA_PORT"; then
+                    echo -e "${GREEN}🐳 Kafka Docker Compose 시작 완료${NC}"
+                    return
+                fi
+            fi
+        fi
+    fi
+
+    # Docker Compose로 시작되지 않으면 안내
+    echo -e "${RED}👿 Kafka 시작 실패. docker-compose 설정 또는 환경변수를 확인하세요.${NC}"
+    echo -e "${YELLOW}💡 수동 실행: docker compose up -d kafka kafka-ui${NC}"
+}
+
 # Gradle Wrapper 실행 권한 확인
 if [ ! -x "./gradlew" ]; then
     chmod +x ./gradlew
@@ -337,6 +386,8 @@ fi
 
 # Redis 시작 (Eureka Server보다 먼저)
 start_redis
+# Kafka 시작 (서비스보다 먼저)
+start_kafka
 
 # 서비스 실행 함수
 start_service() {
@@ -395,6 +446,8 @@ echo -e "  - Eureka Dashboard: ${GREEN}http://localhost:8761${NC}"
 echo -e "  - API Gateway: ${GREEN}http://localhost:8000${NC}"
 echo -e "  - Swagger UI: ${GREEN}http://localhost:8000/swagger-ui.html${NC}"
 echo -e "  - Redis: ${GREEN}localhost:${REDIS_PORT}${NC}"
+echo -e "  - Kafka: ${GREEN}localhost:${KAFKA_PORT}${NC}"
+echo -e "  - Kafka UI: ${GREEN}http://localhost:8080${NC}"
 echo ""
 echo -e "로그 확인: ${YELLOW}dev-scripts/pids/*.log${NC}"
 echo -e "서비스 종료: ${YELLOW}./dev-scripts/stop.sh${NC}"

--- a/dev-scripts/stop.sh
+++ b/dev-scripts/stop.sh
@@ -34,6 +34,7 @@ SERVICES=(
 # Redis 설정 (기본값)
 REDIS_PORT=${REDIS_PORT:-6379}
 REDIS_CONTAINER_NAME="paystream-redis"
+KAFKA_PORT=${KAFKA_PORT:-29092}
 
 # 서비스 종료 함수
 stop_service() {
@@ -205,8 +206,39 @@ stop_redis() {
     echo -e "${YELLOW}⚠️  Redis가 실행 중이 아닙니다.${NC}"
 }
 
+# Kafka 종료 함수
+stop_kafka() {
+    echo -e "${YELLOW}🛑 Kafka 종료 중...${NC}"
+
+    if is_docker_running && [ -f "$PROJECT_ROOT/docker-compose.yml" ]; then
+        cd "$PROJECT_ROOT"
+        if command -v docker-compose > /dev/null 2>&1; then
+            docker-compose stop kafka kafka-ui > /dev/null 2>&1 || true
+        elif docker compose version > /dev/null 2>&1; then
+            docker compose stop kafka kafka-ui > /dev/null 2>&1 || true
+        fi
+    fi
+
+    if command -v lsof > /dev/null 2>&1; then
+        kafka_pids=$(lsof -ti:$KAFKA_PORT 2>/dev/null || true)
+        if [ -n "$kafka_pids" ]; then
+            for pid in $kafka_pids; do
+                kill "$pid" 2>/dev/null || true
+                sleep 1
+                if ps -p "$pid" > /dev/null 2>&1; then
+                    kill -9 "$pid" 2>/dev/null || true
+                fi
+            done
+        fi
+    fi
+
+    echo -e "${GREEN}💚 Kafka 종료 처리 완료${NC}"
+}
+
 # Redis 종료
 stop_redis
+# Kafka 종료
+stop_kafka
 
 echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}모든 서비스 종료 완료!${NC}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   # Kafka
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.6.1
     ports:
       - "29092:29092"
     environment:
@@ -62,9 +62,9 @@ services:
 
   # kafka-ui
   kafka-ui:
-    image: provectuslabs/kafka-ui:latest
+    image: provectuslabs/kafka-ui:v0.7.2
     ports:
-      - "8080:8080"
+      - "8088:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092

--- a/services/api-gateway/src/main/java/com/paystream/apigateway/route/GatewayRoute.java
+++ b/services/api-gateway/src/main/java/com/paystream/apigateway/route/GatewayRoute.java
@@ -111,7 +111,7 @@ public class GatewayRoute {
                                                                         "/${path}")
                                                                 .addRequestHeader(
                                                                         "X-Service-Name",
-                                                                        "user-service"))
+                                                                        "order-service"))
                                         .uri("lb://order-service"))
                 .route(
                         "order-service",
@@ -160,7 +160,7 @@ public class GatewayRoute {
                                                                         "payment-service")
                                                                 .circuitBreaker(
                                                                         circuitBreakerConfig(
-                                                                                "inventory-service")))
+                                                                                "payment-service")))
                                         .uri("lb://payment-service"));
     }
 

--- a/services/api-gateway/src/main/resources/application.yml
+++ b/services/api-gateway/src/main/resources/application.yml
@@ -31,7 +31,7 @@ springdoc:
       url: http://localhost:8000/api/inventories/v3/api-docs
     urls[1]:
       name: 알림 서비스
-      url: http://localhost:8000/api/notification/v3/api-docs
+      url: http://localhost:8000/api/notifications/v3/api-docs
     urls[2]:
       name: 주문 서비스
       url: http://localhost:8000/api/orders/v3/api-docs

--- a/services/order-service/build.gradle
+++ b/services/order-service/build.gradle
@@ -1,31 +1,13 @@
 plugins {
-    id 'java'
     id 'org.springframework.boot' version '3.5.6'
-    id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.paystream'
-version = '0.0.1-SNAPSHOT'
 description = 'Order Service'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
 
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-}
-
-repositories {
-    mavenCentral()
-}
-
-ext {
-    springCloudVersion = "2025.0.0"
 }
 
 dependencies {
@@ -63,14 +45,4 @@ dependencies {
 
     // 공통 라이브러리
     implementation project(':common:core')
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/services/order-service/build.gradle
+++ b/services/order-service/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     // Spring Cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/services/order-service/src/main/java/com/paystream/order/controller/OrderController.java
+++ b/services/order-service/src/main/java/com/paystream/order/controller/OrderController.java
@@ -1,6 +1,8 @@
 package com.paystream.order.controller;
 
 import com.paystream.core.BaseResponse;
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.order.dto.OrderCreateRequest;
 import com.paystream.order.dto.OrderResponse;
 import com.paystream.order.service.OrderService;
@@ -48,13 +50,13 @@ public class OrderController {
     private Long getCurrentUserId(HttpServletRequest request) {
         String userIdHeader = request.getHeader("X-Auth-User-Id");
         if (userIdHeader == null) {
-            throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다. API Gateway를 통해 요청해야 합니다.");
+            throw new PayStreamException(ExceptionEnum.ORDER_MISSING_AUTH_USER_ID);
         }
 
         try {
             return Long.parseLong(userIdHeader);
         } catch (NumberFormatException e) {
-            throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + userIdHeader);
+            throw new PayStreamException(ExceptionEnum.ORDER_INVALID_AUTH_USER_ID);
         }
     }
 }

--- a/services/order-service/src/main/java/com/paystream/order/controller/OrderController.java
+++ b/services/order-service/src/main/java/com/paystream/order/controller/OrderController.java
@@ -1,0 +1,60 @@
+package com.paystream.order.controller;
+
+import com.paystream.core.BaseResponse;
+import com.paystream.order.dto.OrderCreateRequest;
+import com.paystream.order.dto.OrderResponse;
+import com.paystream.order.service.OrderService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    public BaseResponse<OrderResponse> createOrder(
+            @Valid @RequestBody OrderCreateRequest request, HttpServletRequest httpRequest) {
+        Long userId = getCurrentUserId(httpRequest);
+        OrderResponse response = orderService.createOrder(userId, request);
+        return BaseResponse.created(response);
+    }
+
+    @GetMapping("/{id:\\d+}")
+    public BaseResponse<OrderResponse> getOrder(
+            @PathVariable Long id, HttpServletRequest httpRequest) {
+        Long userId = getCurrentUserId(httpRequest);
+        OrderResponse response = orderService.getOrder(userId, id);
+        return BaseResponse.ok(response);
+    }
+
+    @GetMapping
+    public BaseResponse<List<OrderResponse>> getOrders(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size,
+            HttpServletRequest httpRequest) {
+        Long userId = getCurrentUserId(httpRequest);
+        List<OrderResponse> responses = orderService.getOrdersByUserId(userId, page, size);
+        return BaseResponse.ok(responses);
+    }
+
+    private Long getCurrentUserId(HttpServletRequest request) {
+        String userIdHeader = request.getHeader("X-Auth-User-Id");
+        if (userIdHeader == null) {
+            throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다. API Gateway를 통해 요청해야 합니다.");
+        }
+
+        try {
+            return Long.parseLong(userIdHeader);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + userIdHeader);
+        }
+    }
+}

--- a/services/order-service/src/main/java/com/paystream/order/dto/OrderCreateRequest.java
+++ b/services/order-service/src/main/java/com/paystream/order/dto/OrderCreateRequest.java
@@ -1,0 +1,66 @@
+package com.paystream.order.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class OrderCreateRequest {
+
+    @NotNull(message = "주문 금액은 필수입니다")
+    @Min(value = 100, message = "주문 금액은 최소 100원 이상이어야 합니다")
+    private BigDecimal amount;
+
+    @NotBlank(message = "주문명은 필수입니다")
+    private String name;
+
+    @NotNull(message = "상품 ID는 필수입니다")
+    private Long productId;
+
+    @NotNull(message = "체크인 날짜는 필수입니다")
+    private LocalDate checkInDate;
+
+    @NotNull(message = "체크아웃 날짜는 필수입니다")
+    private LocalDate checkOutDate;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public LocalDate getCheckInDate() {
+        return checkInDate;
+    }
+
+    public void setCheckInDate(LocalDate checkInDate) {
+        this.checkInDate = checkInDate;
+    }
+
+    public LocalDate getCheckOutDate() {
+        return checkOutDate;
+    }
+
+    public void setCheckOutDate(LocalDate checkOutDate) {
+        this.checkOutDate = checkOutDate;
+    }
+}

--- a/services/order-service/src/main/java/com/paystream/order/dto/OrderResponse.java
+++ b/services/order-service/src/main/java/com/paystream/order/dto/OrderResponse.java
@@ -1,44 +1,34 @@
-package com.paystream.order.entity;
+package com.paystream.order.dto;
 
-import com.paystream.core.BaseEntity;
-import jakarta.persistence.*;
+import com.paystream.order.entity.Order;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "orders")
-public class Order extends BaseEntity {
+public class OrderResponse {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(name = "user_id", nullable = false)
     private Long userId;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private OrderStatus status;
-
-    @Column(nullable = false)
+    private String status;
     private BigDecimal amount;
-
-    /** 결제 요청 시 사용하는 주문 번호 (merchant_uid, 포트원 등 연동용) */
-    @Column(unique = true)
     private String merchantUid;
-
-    /** 주문명 (결제창 등에 표시) */
-    @Column(nullable = true)
     private String name;
-
-    @Column(name = "product_id", nullable = false)
     private Long productId;
-
-    @Column(name = "check_in_date", nullable = false)
     private LocalDate checkInDate;
-
-    @Column(name = "check_out_date", nullable = false)
     private LocalDate checkOutDate;
+
+    public static OrderResponse from(Order order) {
+        OrderResponse response = new OrderResponse();
+        response.setId(order.getId());
+        response.setUserId(order.getUserId());
+        response.setStatus(order.getStatus().name());
+        response.setAmount(order.getAmount());
+        response.setMerchantUid(order.getMerchantUid());
+        response.setName(order.getName());
+        response.setProductId(order.getProductId());
+        response.setCheckInDate(order.getCheckInDate());
+        response.setCheckOutDate(order.getCheckOutDate());
+        return response;
+    }
 
     public Long getId() {
         return id;
@@ -56,11 +46,11 @@ public class Order extends BaseEntity {
         this.userId = userId;
     }
 
-    public OrderStatus getStatus() {
+    public String getStatus() {
         return status;
     }
 
-    public void setStatus(OrderStatus status) {
+    public void setStatus(String status) {
         this.status = status;
     }
 

--- a/services/order-service/src/main/java/com/paystream/order/event/OrderCreatedEvent.java
+++ b/services/order-service/src/main/java/com/paystream/order/event/OrderCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.paystream.order.event;
+
+import java.time.LocalDate;
+
+/** 주문이 DB에 커밋된 뒤 재고 선점(reserve) Kafka 메시지를 보내기 위한 이벤트입니다. */
+public record OrderCreatedEvent(
+        Long orderId,
+        String userId,
+        Long productId,
+        LocalDate checkInDate,
+        LocalDate checkOutDate) {}

--- a/services/order-service/src/main/java/com/paystream/order/kafka/OrderReserveEventListener.java
+++ b/services/order-service/src/main/java/com/paystream/order/kafka/OrderReserveEventListener.java
@@ -1,0 +1,48 @@
+package com.paystream.order.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paystream.order.event.OrderCreatedEvent;
+import com.paystream.order.kafka.dto.InventoryReservePayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderReserveEventListener {
+
+    public static final String TOPIC_ORDER_INVENTORY_RESERVE = "order.inventory.reserve";
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOrderCreated(OrderCreatedEvent event) {
+        try {
+            InventoryReservePayload payload =
+                    new InventoryReservePayload(
+                            event.userId(),
+                            event.productId(),
+                            event.checkInDate(),
+                            event.checkOutDate());
+            String json = objectMapper.writeValueAsString(payload);
+            kafkaTemplate.send(
+                    TOPIC_ORDER_INVENTORY_RESERVE, String.valueOf(event.orderId()), json);
+            log.debug(
+                    "Kafka reserve published: orderId={}, topic={}",
+                    event.orderId(),
+                    TOPIC_ORDER_INVENTORY_RESERVE);
+        } catch (Exception e) {
+            log.error(
+                    "Kafka reserve publish failed: orderId={}, error={}",
+                    event.orderId(),
+                    e.getMessage(),
+                    e);
+            throw new RuntimeException("재고 선점 이벤트 발행에 실패했습니다.", e);
+        }
+    }
+}

--- a/services/order-service/src/main/java/com/paystream/order/kafka/OrderReserveEventListener.java
+++ b/services/order-service/src/main/java/com/paystream/order/kafka/OrderReserveEventListener.java
@@ -1,6 +1,8 @@
 package com.paystream.order.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.order.event.OrderCreatedEvent;
 import com.paystream.order.kafka.dto.InventoryReservePayload;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +44,7 @@ public class OrderReserveEventListener {
                     event.orderId(),
                     e.getMessage(),
                     e);
-            throw new RuntimeException("재고 선점 이벤트 발행에 실패했습니다.", e);
+            throw new PayStreamException(ExceptionEnum.ORDER_EVENT_PUBLISH_FAILED);
         }
     }
 }

--- a/services/order-service/src/main/java/com/paystream/order/kafka/dto/InventoryReservePayload.java
+++ b/services/order-service/src/main/java/com/paystream/order/kafka/dto/InventoryReservePayload.java
@@ -1,0 +1,54 @@
+package com.paystream.order.kafka.dto;
+
+import java.time.LocalDate;
+
+/** inventory-service {@code InventoryEvent}와 동일한 JSON 스키마로 직렬화합니다. */
+public class InventoryReservePayload {
+
+    private String userId;
+    private Long productId;
+    private LocalDate checkInDate;
+    private LocalDate checkOutDate;
+
+    public InventoryReservePayload() {}
+
+    public InventoryReservePayload(
+            String userId, Long productId, LocalDate checkInDate, LocalDate checkOutDate) {
+        this.userId = userId;
+        this.productId = productId;
+        this.checkInDate = checkInDate;
+        this.checkOutDate = checkOutDate;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Long productId) {
+        this.productId = productId;
+    }
+
+    public LocalDate getCheckInDate() {
+        return checkInDate;
+    }
+
+    public void setCheckInDate(LocalDate checkInDate) {
+        this.checkInDate = checkInDate;
+    }
+
+    public LocalDate getCheckOutDate() {
+        return checkOutDate;
+    }
+
+    public void setCheckOutDate(LocalDate checkOutDate) {
+        this.checkOutDate = checkOutDate;
+    }
+}

--- a/services/order-service/src/main/java/com/paystream/order/service/OrderService.java
+++ b/services/order-service/src/main/java/com/paystream/order/service/OrderService.java
@@ -1,0 +1,80 @@
+package com.paystream.order.service;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.order.dto.OrderCreateRequest;
+import com.paystream.order.dto.OrderResponse;
+import com.paystream.order.entity.Order;
+import com.paystream.order.entity.OrderStatus;
+import com.paystream.order.event.OrderCreatedEvent;
+import com.paystream.order.repository.OrderRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public OrderResponse createOrder(Long userId, OrderCreateRequest request) {
+        if (!request.getCheckOutDate().isAfter(request.getCheckInDate())) {
+            throw new PayStreamException(ExceptionEnum.INVALID_DATE_RANGE);
+        }
+
+        Order order = new Order();
+        order.setUserId(userId);
+        order.setStatus(OrderStatus.PENDING);
+        order.setAmount(request.getAmount());
+        order.setName(request.getName());
+        order.setProductId(request.getProductId());
+        order.setCheckInDate(request.getCheckInDate());
+        order.setCheckOutDate(request.getCheckOutDate());
+
+        Order saved = orderRepository.save(order);
+        saved.setMerchantUid("ORD-" + String.format("%012d", saved.getId()));
+        orderRepository.save(saved);
+
+        eventPublisher.publishEvent(
+                new OrderCreatedEvent(
+                        saved.getId(),
+                        String.valueOf(userId),
+                        saved.getProductId(),
+                        saved.getCheckInDate(),
+                        saved.getCheckOutDate()));
+
+        return OrderResponse.from(saved);
+    }
+
+    public OrderResponse getOrder(Long userId, Long orderId) {
+        Order order =
+                orderRepository
+                        .findById(orderId)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.ORDER_NOT_FOUND));
+        if (!order.getUserId().equals(userId)) {
+            throw new PayStreamException(ExceptionEnum.ORDER_NOT_FOUND);
+        }
+        return OrderResponse.from(order);
+    }
+
+    public List<OrderResponse> getOrdersByUserId(Long userId, Integer page, Integer size) {
+        List<Order> orders = orderRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+
+        int pageNum = (page != null && page > 0) ? page - 1 : 0;
+        int pageSize = (size != null && size > 0) ? size : 20;
+        int start = pageNum * pageSize;
+        int end = Math.min(start + pageSize, orders.size());
+
+        List<Order> paged = start < orders.size() ? orders.subList(start, end) : new ArrayList<>();
+
+        return paged.stream().map(OrderResponse::from).collect(Collectors.toList());
+    }
+}

--- a/services/order-service/src/main/resources/application.yml
+++ b/services/order-service/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     name: order-service
   profiles:
     active: local
+  kafka:
+    bootstrap-servers: ${KAFKA_URL:localhost:29092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 eureka:
   client:

--- a/services/payment-service/build.gradle
+++ b/services/payment-service/build.gradle
@@ -1,31 +1,13 @@
 plugins {
-    id 'java'
     id 'org.springframework.boot' version '3.5.6'
-    id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.paystream'
-version = '0.0.1-SNAPSHOT'
 description = 'Payment Service'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
 
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-}
-
-repositories {
-    mavenCentral()
-}
-
-ext {
-    set('springCloudVersion', "2025.0.0")
 }
 
 dependencies {
@@ -57,14 +39,4 @@ dependencies {
     
     // 공통 라이브러리 가져옴
     implementation project(':common:core')
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/services/payment-service/src/main/java/com/paystream/payment/config/SwaggerConfig.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.paystream.payment.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +15,7 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(components())
                 .info(apiInfo())
                 .servers(
                         List.of(
@@ -25,5 +26,29 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info().title("Payment API").description("Payment API").version("0.0.1-SNAPSHOT");
+    }
+
+    private Components components() {
+        return new Components()
+                .addSecuritySchemes(
+                        "accessToken",
+                        new SecurityScheme()
+                                .name("accessToken")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .bearerFormat("JWT"))
+                .addSecuritySchemes(
+                        "refreshToken",
+                        new SecurityScheme()
+                                .name("refreshToken")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .bearerFormat("JWT"))
+                .addSecuritySchemes(
+                        "X-Auth-User-Id",
+                        new SecurityScheme()
+                                .name("X-Auth-User-Id")
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER));
     }
 }

--- a/services/payment-service/src/main/java/com/paystream/payment/controller/PaymentController.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/controller/PaymentController.java
@@ -1,6 +1,8 @@
 package com.paystream.payment.controller;
 
 import com.paystream.core.BaseResponse;
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.payment.dto.PaymentConfirmDto;
 import com.paystream.payment.dto.PaymentRequestDto;
 import com.paystream.payment.dto.PaymentResponseDto;
@@ -103,13 +105,13 @@ public class PaymentController {
     private Long getCurrentUserId(HttpServletRequest request) {
         String userIdHeader = request.getHeader("X-Auth-User-Id");
         if (userIdHeader == null) {
-            throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다. API Gateway를 통해 요청해야 합니다.");
+            throw new PayStreamException(ExceptionEnum.PAYMENT_MISSING_AUTH_USER_ID);
         }
 
         try {
             return Long.parseLong(userIdHeader);
         } catch (NumberFormatException e) {
-            throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + userIdHeader);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_INVALID_AUTH_USER_ID);
         }
     }
 }

--- a/services/payment-service/src/main/java/com/paystream/payment/service/PortOneService.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/service/PortOneService.java
@@ -2,6 +2,8 @@ package com.paystream.payment.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.payment.dto.PortOnePaymentResponse;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -84,17 +86,17 @@ public class PortOneService {
                             .block();
 
             if (response == null) {
-                throw new RuntimeException("포트원 API 응답이 null입니다.");
+                throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
             }
 
             return parsePaymentData(response);
 
         } catch (WebClientResponseException e) {
             handleWebClientResponseException(e, paymentId);
-            throw new RuntimeException("포트원 결제 조회 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         } catch (Exception e) {
             log.error("포트원 결제 조회 중 오류 발생: paymentId={}, error={}", paymentId, e.getMessage(), e);
-            throw new RuntimeException("포트원 결제 조회 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         }
     }
 
@@ -118,12 +120,12 @@ public class PortOneService {
                             .block();
 
             if (response == null) {
-                throw new RuntimeException("포트원 취소 API 응답이 null입니다.");
+                throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
             }
 
         } catch (WebClientResponseException e) {
             if (e.getStatusCode().value() == 409) {
-                throw new RuntimeException("포트원 결제 취소 처리 중입니다. 잠시 후 다시 시도해주세요.", e);
+                throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_CANCEL_CONFLICT);
             }
             log.error(
                     "포트원 취소 API 호출 중 오류 발생: paymentId={}, status={}, error={}",
@@ -131,10 +133,10 @@ public class PortOneService {
                     e.getStatusCode(),
                     e.getMessage(),
                     e);
-            throw new RuntimeException("포트원 결제 취소 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         } catch (Exception e) {
             log.error("포트원 결제 취소 중 오류 발생: paymentId={}, error={}", paymentId, e.getMessage(), e);
-            throw new RuntimeException("포트원 결제 취소 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         }
     }
 
@@ -162,7 +164,7 @@ public class PortOneService {
                             .block();
 
             if (response == null) {
-                throw new RuntimeException("포트원 API 응답이 null입니다.");
+                throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
             }
 
             List<PortOnePaymentResponse.PaymentData> paymentList = new ArrayList<>();
@@ -189,16 +191,13 @@ public class PortOneService {
                 try {
                     JsonNode errorBody = objectMapper.readTree(responseBody);
                     if (errorBody.has("type") && errorBody.has("message")) {
-                        String errorType = errorBody.get("type").asText();
-                        String errorMessage = errorBody.get("message").asText();
-                        throw new RuntimeException(
-                                "포트원 API 요청 형식 오류 (" + errorType + "): " + errorMessage, e);
+                        throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_BAD_REQUEST);
                     }
                 } catch (Exception parseException) {
                 }
             }
 
-            throw new RuntimeException("포트원 결제 목록 조회 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         } catch (Exception e) {
             log.error(
                     "포트원 결제 목록 조회 중 오류 발생: page={}, size={}, error={}",
@@ -206,7 +205,7 @@ public class PortOneService {
                     size,
                     e.getMessage(),
                     e);
-            throw new RuntimeException("포트원 결제 목록 조회 실패: " + e.getMessage(), e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_ERROR);
         }
     }
 
@@ -286,7 +285,7 @@ public class PortOneService {
 
     private void validateApiSecret() {
         if (apiSecret == null || apiSecret.isEmpty()) {
-            throw new RuntimeException("포트원 API Secret이 설정되지 않았습니다.");
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_API_SECRET_MISSING);
         }
     }
 
@@ -296,25 +295,22 @@ public class PortOneService {
 
         if (statusCode == 401) {
             log.error("포트원 API 인증 실패 (401): paymentId={}", paymentId);
-            throw new RuntimeException("포트원 API 인증 실패: API Secret을 확인하세요.", e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_UNAUTHORIZED);
         }
         if (statusCode == 400) {
             log.error("포트원 API 요청 형식 오류 (400): paymentId={}", paymentId);
             try {
                 JsonNode errorBody = objectMapper.readTree(responseBody);
                 if (errorBody.has("type") && errorBody.has("message")) {
-                    String errorType = errorBody.get("type").asText();
-                    String errorMessage = errorBody.get("message").asText();
-                    throw new RuntimeException(
-                            "포트원 API 요청 형식 오류 (" + errorType + "): " + errorMessage, e);
+                    throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_BAD_REQUEST);
                 }
             } catch (Exception parseException) {
             }
-            throw new RuntimeException("포트원 API 요청 형식 오류: paymentId 형식이나 엔드포인트를 확인하세요.", e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_BAD_REQUEST);
         }
         if (statusCode == 404) {
             log.error("포트원 결제 건을 찾을 수 없음 (404): paymentId={}", paymentId);
-            throw new RuntimeException("포트원 결제 건을 찾을 수 없습니다. paymentId를 확인하세요.", e);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_PORTONE_NOT_FOUND);
         }
         log.error(
                 "포트원 API 호출 중 오류 발생: paymentId={}, status={}, error={}",

--- a/services/payment-service/src/main/java/com/paystream/payment/util/RequestUtil.java
+++ b/services/payment-service/src/main/java/com/paystream/payment/util/RequestUtil.java
@@ -1,5 +1,7 @@
 package com.paystream.payment.util;
 
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import jakarta.servlet.http.HttpServletRequest;
 
 /** HTTP 요청 관련 유틸리티 */
@@ -10,18 +12,18 @@ public class RequestUtil {
      *
      * @param request HTTP 요청
      * @return 사용자 ID
-     * @throws RuntimeException 헤더가 없거나 유효하지 않은 경우
+     * @throws PayStreamException 헤더가 없거나 유효하지 않은 경우
      */
     public static Long getCurrentUserId(HttpServletRequest request) {
         String userIdHeader = request.getHeader("X-Auth-User-Id");
         if (userIdHeader == null) {
-            throw new RuntimeException("인증된 사용자 정보를 찾을 수 없습니다. API Gateway를 통해 요청해야 합니다.");
+            throw new PayStreamException(ExceptionEnum.PAYMENT_MISSING_AUTH_USER_ID);
         }
 
         try {
             return Long.parseLong(userIdHeader);
         } catch (NumberFormatException e) {
-            throw new RuntimeException("유효하지 않은 사용자 ID입니다: " + userIdHeader);
+            throw new PayStreamException(ExceptionEnum.PAYMENT_INVALID_AUTH_USER_ID);
         }
     }
 }

--- a/services/user-service/build.gradle
+++ b/services/user-service/build.gradle
@@ -1,18 +1,8 @@
 plugins {
-    id 'java'
     id 'org.springframework.boot' version '3.5.6'
-    id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.paystream'
-version = '0.0.1-SNAPSHOT'
 description = 'User Service'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
 
 configurations {
     compileOnly {
@@ -20,23 +10,11 @@ configurations {
     }
 }
 
-repositories {
-    mavenCentral()
-}
-
-ext {
-    springCloudVersion = "2025.0.0"   // Spring Boot 3.5.x와 호환
-}
-
 dependencies {
     // spring boot starter
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-    // lombok
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -70,14 +48,4 @@ dependencies {
     // 공통 라이브러리 가져옴
     implementation project(':common:core')
 
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-    }
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/services/user-service/src/main/java/com/paystream/user/controller/AuthController.java
+++ b/services/user-service/src/main/java/com/paystream/user/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.paystream.user.controller;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.paystream.core.BaseResponse;
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.user.dto.request.LoginRequest;
 import com.paystream.user.dto.request.RefreshTokenRequest;
 import com.paystream.user.dto.request.SignupRequest;
@@ -49,7 +51,7 @@ public class AuthController {
     public BaseResponse<String> logout(
             @RequestHeader(value = AUTHORIZATION, required = false) String authorization) {
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Authorization 헤더에 Bearer 토큰이 필요합니다.");
+            throw new PayStreamException(ExceptionEnum.USER_MISSING_BEARER_TOKEN);
         }
 
         String accessToken = authorization.substring(7);

--- a/services/user-service/src/main/java/com/paystream/user/service/TokenBlacklistService.java
+++ b/services/user-service/src/main/java/com/paystream/user/service/TokenBlacklistService.java
@@ -1,5 +1,7 @@
 package com.paystream.user.service;
 
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
 import com.paystream.user.util.JwtUtil;
 import io.jsonwebtoken.Claims;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +39,7 @@ public class TokenBlacklistService {
             }
         } catch (Exception e) {
             log.error("블랙리스트 추가 중 오류 발생", e);
-            throw new RuntimeException("블랙리스트 추가 실패", e);
+            throw new PayStreamException(ExceptionEnum.USER_BLACKLIST_ADD_FAILED);
         }
     }
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- order-service에 주문 생성/조회 기능을 추가하고, 주문 생성 시 Kafka `order.inventory.reserve` 이벤트가 발행되도록 연동
- gateway 라우팅/Swagger 집계 오타 수정, payment-service Swagger 인증 스키마 정리, dev-scripts Kafka 자동 기동/종료 지원 반영
- 공통 예외 체계를 확장하고(order/payment/user), 서비스별 예외 처리를 `PayStreamException + ExceptionEnum` 기반으로 통일
- CI 변경 감지 조건 최적화, docker-compose Kafka 이미지 태그 고정 및 Kafka UI 포트 조정, 일부 서비스 Gradle 중복 설정 정리

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- common/core
  - `ExceptionEnum` 확장
    - order: 인증 헤더 누락/형식 오류, 이벤트 발행 실패 코드 추가
    - payment: 인증 헤더 누락/형식 오류, PortOne 오류 세분화 코드 추가
    - user: Bearer 토큰 누락, 블랙리스트 추가 실패 코드 추가
- order-service
  - `Order` 엔티티 확장: `productId`, `checkInDate`, `checkOutDate` 추가
  - DTO 추가/확장: `OrderCreateRequest`, `OrderResponse`
  - Kafka 설정/의존성 추가: `spring-kafka`, `application.yml` producer 설정
  - 서비스 구현: `createOrder`, `getOrder`, `getOrdersByUserId`
  - 이벤트 구현:
    - `OrderCreatedEvent`
    - `OrderReserveEventListener` (`@TransactionalEventListener(AFTER_COMMIT)`)
    - `InventoryReservePayload`
  - 컨트롤러 구현: `POST /orders`, `GET /orders/{id}`, `GET /orders`
  - 예외 처리 정렬:
    - 인증 헤더 파싱 오류를 `PayStreamException`으로 통일
    - Kafka 발행 실패를 `ORDER_EVENT_PUBLISH_FAILED`로 변환
- payment-service
  - Swagger `SecurityScheme` 추가 (`accessToken`, `refreshToken`, `X-Auth-User-Id`)
  - 예외 처리 정렬:
    - `PaymentController`, `RequestUtil`의 인증 헤더 예외 통일
    - `PortOneService` 외부 연동 예외를 공통 예외 코드로 세분화/통일
- user-service
  - 예외 처리 정렬:
    - `AuthController` Bearer 토큰 누락 예외 통일
    - `TokenBlacklistService` 블랙리스트 저장 실패 예외 통일
- api-gateway
  - `GatewayRoute` 오타 수정
    - order swagger route `X-Service-Name`: `user-service` -> `order-service`
    - payment route circuit breaker fallback 대상: `inventory-service` -> `payment-service`
  - Swagger 집계 URL 오타 수정
    - notification docs 경로를 `.../api/notifications/v3/api-docs`로 정정
- dev-scripts
  - `start.sh`에 Kafka/Kafka UI 자동 시작 로직 추가
  - `stop.sh`에 Kafka/Kafka UI 자동 종료 로직 추가
  - README 사용 안내 업데이트
- CI / 인프라 / 빌드
  - `.github/workflows/ci.yml`
    - 변경 감지 `any`에서 `services/**` 제거
    - 서비스별 빌드 조건을 “모듈 변경 시 선택 빌드 + common/core 변경 시 전체 빌드”로 조정
  - `docker-compose.yml`
    - `kafka`, `kafka-ui` 이미지 `latest` 제거 및 태그 pinning
    - `kafka-ui` 포트 `8088:8080`으로 변경
  - `services/{order,payment,user}/build.gradle`
    - 루트와 중복되는 공통 설정 제거(서비스 고유 의존성은 유지)

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 컴파일 확인
   - `./gradlew :common:core:compileJava`
   - `./gradlew :services:order-service:compileJava`
   - `./gradlew :services:payment-service:compileJava`
   - `./gradlew :services:user-service:compileJava`
2. compose 설정 확인
   - `docker compose config`
3. 스크립트 문법 확인
   - `bash -n dev-scripts/start.sh`
   - `bash -n dev-scripts/stop.sh`
4. 기능 확인
   - `docker compose up -d kafka kafka-ui redis`
   - 서비스 기동 후 `POST /api/orders` 호출
   - inventory-service 로그에서 `order.inventory.reserve` consume 여부 확인
   - gateway swagger 집계 경로(notification 포함) 접근 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션을 통과함
- [x] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
- `.env`의 Kafka 관련 값이 없으면 dev-scripts에서 Kafka 기동이 실패할 수 있으니 환경변수 확인이 필요합니다
- CI는 모듈 영향 기반으로 빌드되며, `common/core` 변경 시 전체 서비스 빌드가 됩니다

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #