### PR TITLE
fix(notification): API Gateway와 맞춰 알림 API 베이스 경로를 /notifications로 통일

### DIFF
--- a/services/notification-service/src/main/java/com/paystream/notification/controller/HealthController.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/controller/HealthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 헬스 체크 컨트롤러 - 서비스 정상 동작 확인용 엔드포인트 제공 */
 @Slf4j
 @RestController
-@RequestMapping("/api/notifications")
+@RequestMapping("/notifications")
 public class HealthController {
 
     /**

--- a/services/notification-service/src/main/java/com/paystream/notification/controller/NotificationController.java
+++ b/services/notification-service/src/main/java/com/paystream/notification/controller/NotificationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 /** 알림 컨트롤러 - 알림 관련 REST API 엔드포인트 제공 */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notifications")
+@RequestMapping("/notifications")
 public class NotificationController {
 
     private final NotificationCreateService notificationCreateService;

--- a/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
+++ b/services/notification-service/src/test/java/com/paystream/notification/controller/HealthControllerTests.java
@@ -1,7 +1,8 @@
 package com.paystream.notification.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ class HealthControllerTests {
     @Test
     @DisplayName("ping 엔드포인트 - 정상 응답 확인")
     void testPingEndpoint() throws Exception {
-        mockMvc.perform(get("/api/notifications/ping"))
+        mockMvc.perform(get("/notifications/ping"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.service").value("notification-service"))
                 .andExpect(jsonPath("$.status").value("UP"))
@@ -33,7 +34,7 @@ class HealthControllerTests {
     @Test
     @DisplayName("info 엔드포인트 - 서비스 정보 조회")
     void testInfoEndpoint() throws Exception {
-        mockMvc.perform(get("/api/notifications/info"))
+        mockMvc.perform(get("/notifications/info"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("PayStream Notification Service"))
                 .andExpect(jsonPath("$.version").value("0.0.1-SNAPSHOT"))

--- a/services/notification-service/src/test/java/com/paystream/notification/controller/NotificationControllerTest.java
+++ b/services/notification-service/src/test/java/com/paystream/notification/controller/NotificationControllerTest.java
@@ -75,7 +75,7 @@ class NotificationControllerTest {
 
         // when & then
         mockMvc.perform(
-                        post("/api/notifications")
+                        post("/notifications")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -96,7 +96,7 @@ class NotificationControllerTest {
 
         // when & then
         mockMvc.perform(
-                        post("/api/notifications")
+                        post("/notifications")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -120,7 +120,7 @@ class NotificationControllerTest {
         when(notificationFindService.findById(notificationId)).thenReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/notifications/{id}", notificationId))
+        mockMvc.perform(get("/notifications/{id}", notificationId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(notificationId))
                 .andExpect(jsonPath("$.data.userId").value(1L))
@@ -157,7 +157,7 @@ class NotificationControllerTest {
         when(notificationFindService.findByUserId(userId)).thenReturn(responses);
 
         // when & then
-        mockMvc.perform(get("/api/notifications/users/{userId}", userId))
+        mockMvc.perform(get("/notifications/users/{userId}", userId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(2))
@@ -187,7 +187,7 @@ class NotificationControllerTest {
 
         // when & then
         mockMvc.perform(
-                        put("/api/notifications/{id}", notificationId)
+                        put("/notifications/{id}", notificationId)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 📌 PR 개요
- API Gateway에서 `/api` 프리픽스를 제거한 뒤 백엔드로 전달되므로, 알림 서비스 컨트롤러의 `@RequestMapping`을 `/api/notifications`에서 `/notifications`로 통일. 이중 경로(`/api/api/...`) 불일치를 방지.

## 🔍 변경 사항
- `HealthController`, `NotificationController`: 베이스 경로 `/notifications`로 변경
- `HealthControllerTests`, `NotificationControllerTest`: MockMvc 요청 URL을 동일하게 수정
- `HealthControllerTests`: `MockMvcResultMatchers` 와일드카드 import를 `jsonPath`, `status` 개별 import로 정리

## 🧪 테스트 방법
1. `notification-service` 모듈에서 `./gradlew :services:notification-service:test` 실행 (또는 루트에서 해당 모듈 테스트만 실행)
2. 통과 확인: `HealthControllerTests`, `NotificationControllerTest` 전부 그린
3. (선택사항) 게이트웨이 경유 시 `GET /api/notifications/ping` 등이 기존과 동일하게 동작하는지 확인

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
- 클라이언트/게이트웨이는 계속 `/api/notifications`를 쓰면 되고, **서비스 내부 매핑만** `/notifications`로 맞춘 변경입니다.

## 📎 참고 이슈
Ref: #