### PR TITLE
숙소 할인 이력 조회 API 구현

### DIFF
--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -12,6 +12,7 @@ public enum ExceptionEnum {
     INTERNAL_SERVER_ERROR("E0003", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_STATUS_VALUE("E0004", HttpStatus.BAD_REQUEST, "상태값을 다시 확인해주세요."),
     IS_NOT_CREATE_USER("E0005", HttpStatus.FORBIDDEN, "사용자의 정보가 다릅니다."),
+    INVALID_DATE_RANGE("E0006", HttpStatus.BAD_REQUEST, " 날짜 범위가 잘못되었습니다."),
 
     /*
        inventory-service -> I0001
@@ -31,7 +32,6 @@ public enum ExceptionEnum {
     PRODUCT_DELETION_BLOCKED("I0008", HttpStatus.CONFLICT, "삭제가 불가능한 상품이 있습니다 다시 확인해주세요."),
     PRODUCT_STORE_MISMATCH("I0009", HttpStatus.BAD_REQUEST, "가게에 포함된 상품이 아닙니다."),
     INVENTORY_NOT_FOUND("I0010", HttpStatus.NOT_FOUND, "상품의 재고가 존재하지 않습니다."),
-    INVALID_DATE_RANGE("I0011", HttpStatus.BAD_REQUEST, "체크인 날짜와 체크아웃 날짜가 바뀌었습니다. 다시 확인해주세요."),
     OUT_OF_BOOKING_PERIOD("I0012", HttpStatus.BAD_REQUEST, "현재 예약 가능 기간이 아닙니다."),
     INSUFFICIENT_STOCK("I0013", HttpStatus.CONFLICT, "재고가 부족한 날짜가 있습니다. 다시 확인해주세요."),
     INVALID_STOCK_CANCEL_REQUEST("I0014", HttpStatus.BAD_REQUEST, "재고 정보가 올바르지 않아 취소할 수 없습니다."),

--- a/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
+++ b/common/core/src/main/java/com/paystream/core/exception/ExceptionEnum.java
@@ -43,6 +43,7 @@ public enum ExceptionEnum {
     OVER_STOCK_FLOW("I0020", HttpStatus.CONFLICT, "저장 가능한 최대 수량을 초과하였습니다."),
     ALREADY_RESERVED_BY_USER("I0021", HttpStatus.BAD_REQUEST, "이미 해당 사용자가 선점(예약 시도) 중인 상품입니다."),
     RESERVATION_EXPIRED("I0022", HttpStatus.BAD_REQUEST, "유휴시간을 초과했습니다."),
+    DATE_EXCEEDS_MAX_RANGE("I0023", HttpStatus.BAD_REQUEST, "시작일 기준 최대 1년까지만 조회할 수 잇습니다."),
 
     // user-service -> U0001
     USER_NOT_FOUND("U0001", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductController.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductController.java
@@ -67,5 +67,7 @@ public interface ProductController {
 
     @Operation(summary = "역대 최저가 숙소 조회", description = "해당 숙소의 역대 ")
     BaseResponse<List<ProductPriceHistoryResponse>> getProductPriceHistory(
-            @PathVariable Long productId);
+            @PathVariable Long productId,
+            @RequestParam LocalDate startDate,
+            @RequestParam LocalDate endDate);
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductController.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.paystream.inventory.product.dto.request.ProductCreateRequest;
 import com.paystream.inventory.product.dto.request.ProductDeleteRequest;
 import com.paystream.inventory.product.dto.request.ProductUpdateRequest;
 import com.paystream.inventory.product.dto.response.ProductDetailResponse;
+import com.paystream.inventory.product.dto.response.ProductPriceHistoryResponse;
 import com.paystream.inventory.product.dto.response.ProductResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -63,4 +64,8 @@ public interface ProductController {
             description = "로그인한 사용자가 소유한 상품 목록을 조회합니다.",
             security = {@SecurityRequirement(name = "X-Auth-User-Id")})
     BaseResponse<List<ProductResponse>> findOwnedProductList(HttpServletRequest request);
+
+    @Operation(summary = "역대 최저가 숙소 조회", description = "해당 숙소의 역대 ")
+    BaseResponse<List<ProductPriceHistoryResponse>> getProductPriceHistory(
+            @PathVariable Long productId);
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductControllerImpl.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductControllerImpl.java
@@ -102,9 +102,11 @@ public class ProductControllerImpl implements ProductController {
     @GetMapping("{productId}/price-history")
     @Override
     public BaseResponse<List<ProductPriceHistoryResponse>> getProductPriceHistory(
-            @PathVariable Long productId) {
+            @PathVariable Long productId,
+            @RequestParam LocalDate startDate,
+            @RequestParam LocalDate endDate) {
         List<ProductPriceHistoryResponse> response =
-                productPriceHistoryService.getPriceHistoryDetails(productId);
+                productPriceHistoryService.getPriceHistoryDetails(productId, startDate, endDate);
 
         return BaseResponse.ok(response);
     }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductControllerImpl.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/controller/ProductControllerImpl.java
@@ -7,11 +7,9 @@ import com.paystream.inventory.product.dto.request.ProductCreateRequest;
 import com.paystream.inventory.product.dto.request.ProductDeleteRequest;
 import com.paystream.inventory.product.dto.request.ProductUpdateRequest;
 import com.paystream.inventory.product.dto.response.ProductDetailResponse;
+import com.paystream.inventory.product.dto.response.ProductPriceHistoryResponse;
 import com.paystream.inventory.product.dto.response.ProductResponse;
-import com.paystream.inventory.product.service.ProductCreateService;
-import com.paystream.inventory.product.service.ProductDeleteService;
-import com.paystream.inventory.product.service.ProductFindService;
-import com.paystream.inventory.product.service.ProductUpdateService;
+import com.paystream.inventory.product.service.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -30,6 +28,7 @@ public class ProductControllerImpl implements ProductController {
     private final ProductCreateService productCreateService;
     private final ProductUpdateService productUpdateService;
     private final ProductDeleteService productDeleteService;
+    private final ProductPriceHistoryService productPriceHistoryService;
 
     @GetMapping("/{productId}")
     @Override
@@ -96,6 +95,16 @@ public class ProductControllerImpl implements ProductController {
         String hostId = getCurrentUserId(request);
 
         List<ProductResponse> response = productFindService.listUserProducts(hostId);
+
+        return BaseResponse.ok(response);
+    }
+
+    @GetMapping("{productId}/price-history")
+    @Override
+    public BaseResponse<List<ProductPriceHistoryResponse>> getProductPriceHistory(
+            @PathVariable Long productId) {
+        List<ProductPriceHistoryResponse> response =
+                productPriceHistoryService.getPriceHistoryDetails(productId);
 
         return BaseResponse.ok(response);
     }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/PriceInfo.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/PriceInfo.java
@@ -10,6 +10,6 @@ import lombok.Getter;
 public class PriceInfo {
     private long original; // 원가
     private long discounted; // 최종가
-    private int discountRate; // 할인율
+    private double discountRate; // 할인율
     private boolean hasDiscount; // 할인 여부
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/ProductPriceHistoryResponse.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/ProductPriceHistoryResponse.java
@@ -1,0 +1,32 @@
+package com.paystream.inventory.product.dto.response;
+
+import com.paystream.inventory.promotion.dto.response.DiscountResult;
+import com.paystream.inventory.promotion.entity.Promotion;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductPriceHistoryResponse {
+
+    private LocalDate startDate; // 시작일
+    private LocalDate endDate; // 종료일
+    private long originPrice; // 원가
+    private long discountedPrice; // 최종가
+    private double discountRate; // 할인율
+
+    public static ProductPriceHistoryResponse of(Promotion promo, DiscountResult result) {
+        return ProductPriceHistoryResponse.builder()
+                .startDate(promo.getStartDate())
+                .endDate(promo.getEndDate())
+                .originPrice(result.getOriginPrice())
+                .discountedPrice(result.getDiscountedPrice())
+                .discountRate(result.getDiscountRate())
+                .build();
+    }
+}

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/ProductResponse.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/dto/response/ProductResponse.java
@@ -33,7 +33,7 @@ public class ProductResponse {
             List<String> images,
             long originalPrice,
             long finalPrice,
-            int rate) {
+            double rate) {
         return ProductResponse.builder()
                 .id(product.getId())
                 .name(product.getName())
@@ -45,7 +45,7 @@ public class ProductResponse {
                                 .original(originalPrice)
                                 .discounted(finalPrice)
                                 .discountRate(rate)
-                                .hasDiscount(rate > 0)
+                                .hasDiscount(rate > 0.0)
                                 .build())
                 .isAvailable(isAvailable)
                 .images(images)

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/entity/Product.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/entity/Product.java
@@ -34,27 +34,12 @@ public class Product extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-    @Column(nullable = false)
     private String name;
-
-    @Column(nullable = false)
     private String description;
-
-    //    private String thumbnail;
-
-    @Column(nullable = false)
     private int minPersonCount; // 최소 수용인원
-
-    @Column(nullable = false)
     private int maxPersonCount; // 최대 수용인원
-
-    @Column(nullable = false)
     private int basePrice;
-
-    @Column(nullable = false)
     private int personAddPrice; // 인원 추가 비용
-
-    @Column(nullable = false)
     private int baseStock;
 
     // '상품' 하나는 '여러' 날짜별 재고를 가진다.

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
@@ -1,0 +1,67 @@
+package com.paystream.inventory.product.service;
+
+import static com.paystream.inventory.promotion.service.DiscountCalculate.calculateAmount;
+import static com.paystream.inventory.promotion.service.DiscountCalculate.createDiscountResult;
+
+import com.paystream.core.exception.ExceptionEnum;
+import com.paystream.core.exception.PayStreamException;
+import com.paystream.inventory.product.dto.response.ProductPriceHistoryResponse;
+import com.paystream.inventory.product.entity.Product;
+import com.paystream.inventory.product.repository.ProductRepository;
+import com.paystream.inventory.promotion.dto.response.DiscountResult;
+import com.paystream.inventory.promotion.entity.Promotion;
+import com.paystream.inventory.promotion.repository.PromotionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class ProductPriceHistoryService {
+
+    private final ProductRepository productRepository;
+    private final PromotionRepository promotionRepository;
+
+    /** 숙소의 세일 내역을 포함한 상세 데이터 조회 */
+    public List<ProductPriceHistoryResponse> getPriceHistoryDetails(Long productId) {
+        Product findProduct =
+                productRepository
+                        .findById(productId)
+                        .orElseThrow(() -> new PayStreamException(ExceptionEnum.PRODUCT_NOT_FOUND));
+
+        // 조회한 숙소id로 promotion을 조회하고, 적용됐던 할인 이력을 가져온다.
+        List<Promotion> targetPromotionList =
+                promotionRepository.findByTargetId(findProduct.getId());
+
+        if (targetPromotionList.isEmpty()) {
+            throw new PayStreamException(ExceptionEnum.PROMOTION_NOT_FOUND);
+        }
+
+        // 숙소의 할인 내역 리스트 조회
+        // 시작일, 종료일, 원가, 최종가, 할인율 계산
+        return calculateProductDiscount(findProduct.getBasePrice(), targetPromotionList);
+    }
+
+    /**
+     * 해당 숙소의 할인 정보를 리스트로 조회
+     *
+     * @param originPrice
+     * @param productPromos
+     * @return
+     */
+    private List<ProductPriceHistoryResponse> calculateProductDiscount(
+            long originPrice, List<Promotion> productPromos) {
+        return productPromos.stream()
+                .map(
+                        promo -> {
+                            long discountPrice = calculateAmount(originPrice, promo);
+                            DiscountResult result =
+                                    createDiscountResult(originPrice, discountPrice);
+
+                            return ProductPriceHistoryResponse.of(promo, result);
+                        })
+                .toList();
+    }
+}

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
@@ -1,5 +1,7 @@
 package com.paystream.inventory.product.service;
 
+import static com.paystream.core.exception.ExceptionEnum.DATE_EXCEEDS_MAX_RANGE;
+import static com.paystream.core.exception.ExceptionEnum.INVALID_DATE_RANGE;
 import static com.paystream.inventory.promotion.service.DiscountCalculate.calculateAmount;
 import static com.paystream.inventory.promotion.service.DiscountCalculate.createDiscountResult;
 
@@ -30,7 +32,13 @@ public class ProductPriceHistoryService {
     public List<ProductPriceHistoryResponse> getPriceHistoryDetails(
             Long productId, LocalDate startDate, LocalDate endDate) {
         if (!startDate.isBefore(endDate)) {
-            throw new PayStreamException(ExceptionEnum.INVALID_DATE_RANGE);
+            throw new PayStreamException(INVALID_DATE_RANGE);
+        }
+
+        // 오늘 기준 최대 1년 전까지만 조회
+        LocalDate nowBeforeOneYears = LocalDate.now().minusYears(1);
+        if (startDate.isBefore(nowBeforeOneYears)) {
+            throw new PayStreamException(DATE_EXCEEDS_MAX_RANGE);
         }
 
         Product findProduct =

--- a/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/product/service/ProductPriceHistoryService.java
@@ -11,6 +11,7 @@ import com.paystream.inventory.product.repository.ProductRepository;
 import com.paystream.inventory.promotion.dto.response.DiscountResult;
 import com.paystream.inventory.promotion.entity.Promotion;
 import com.paystream.inventory.promotion.repository.PromotionRepository;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +25,14 @@ public class ProductPriceHistoryService {
     private final ProductRepository productRepository;
     private final PromotionRepository promotionRepository;
 
+    // 날짜를 최대 1년로 설정해서 1개월, 3개월, 6개월, 1년까지 조회가능. 날짜는 커스텀이 가능.
     /** 숙소의 세일 내역을 포함한 상세 데이터 조회 */
-    public List<ProductPriceHistoryResponse> getPriceHistoryDetails(Long productId) {
+    public List<ProductPriceHistoryResponse> getPriceHistoryDetails(
+            Long productId, LocalDate startDate, LocalDate endDate) {
+        if (!startDate.isBefore(endDate)) {
+            throw new PayStreamException(ExceptionEnum.INVALID_DATE_RANGE);
+        }
+
         Product findProduct =
                 productRepository
                         .findById(productId)
@@ -33,7 +40,8 @@ public class ProductPriceHistoryService {
 
         // 조회한 숙소id로 promotion을 조회하고, 적용됐던 할인 이력을 가져온다.
         List<Promotion> targetPromotionList =
-                promotionRepository.findByTargetId(findProduct.getId());
+                promotionRepository.findByProductTargetIdBetweenDate(
+                        findProduct.getId(), startDate, endDate);
 
         if (targetPromotionList.isEmpty()) {
             throw new PayStreamException(ExceptionEnum.PROMOTION_NOT_FOUND);

--- a/services/inventory-service/src/main/java/com/paystream/inventory/promotion/dto/response/DiscountResult.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/promotion/dto/response/DiscountResult.java
@@ -9,10 +9,6 @@ public class DiscountResult {
 
     private final long originPrice; // 원가
     private final long discountedPrice; // 최종가
-    private final int discountRate; // 할인율 (0~100)
+    private final double discountRate; // 할인율 (0~100)
     private final long discountAmount; // 할인된 금액 (원가 - 최종가)
-
-    public static DiscountResult noDiscount(long originPrice) {
-        return new DiscountResult(originPrice, originPrice, 0, 0);
-    }
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/promotion/repository/PromotionRepository.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/promotion/repository/PromotionRepository.java
@@ -49,5 +49,13 @@ public interface PromotionRepository extends JpaRepository<Promotion, Long> {
             LocalDate endDate,
             Pageable pageable);
 
-    List<Promotion> findByTargetId(Long targetId);
+    @Query(
+            "SELECT p FROM Promotion p "
+                    + "WHERE p.targetId = :targetId "
+                    + "AND p.targetType = com.paystream.inventory.promotion.entity.TargetType.PRODUCT "
+                    + "AND p.startDate >= :startDate "
+                    + "AND p.endDate <= :endDate "
+                    + "ORDER BY p.startDate DESC")
+    List<Promotion> findByProductTargetIdBetweenDate(
+            Long targetId, LocalDate startDate, LocalDate endDate);
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/promotion/repository/PromotionRepository.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/promotion/repository/PromotionRepository.java
@@ -48,4 +48,6 @@ public interface PromotionRepository extends JpaRepository<Promotion, Long> {
             LocalDate startDate,
             LocalDate endDate,
             Pageable pageable);
+
+    List<Promotion> findByTargetId(Long targetId);
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/promotion/service/DiscountCalculate.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/promotion/service/DiscountCalculate.java
@@ -4,6 +4,7 @@ import com.paystream.inventory.promotion.dto.response.DiscountResult;
 import com.paystream.inventory.promotion.entity.DiscountType;
 import com.paystream.inventory.promotion.entity.Promotion;
 import java.util.List;
+import java.util.OptionalDouble;
 import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
@@ -12,35 +13,66 @@ public class DiscountCalculate {
 
     public DiscountResult calculateBestDiscount(
             long originPrice, List<Promotion> storePromos, List<Promotion> productPromos) {
-        // 1. 모든 프로모션 중 최대 할인액 찾기
+        // 모든 프로모션 중 최대 할인액 찾기
         long maxDiscountAmount =
                 Stream.concat(storePromos.stream(), productPromos.stream())
                         .mapToLong(p -> calculateAmount(originPrice, p))
                         .max()
                         .orElse(0L);
 
-        if (maxDiscountAmount <= 0) {
-            return DiscountResult.noDiscount(originPrice);
-        }
-
-        // 2. 최종 가격 및 할인율 계산
-        long finalPrice = Math.max(0, originPrice - maxDiscountAmount);
-        int discountRate = (int) (((double) maxDiscountAmount / originPrice) * 100);
-
-        return new DiscountResult(originPrice, finalPrice, discountRate, maxDiscountAmount);
+        // 할인 결과 생성
+        return createDiscountResult(originPrice, maxDiscountAmount);
     }
 
     /**
-     * 할인율 적용 가격 계산
+     * 항닝 결과 객체 생성 (검증 및 소수점 처리 포함)
      *
-     * @param price 할인 전 가격
-     * @param promotion 프로모션
-     * @return 할인이 적용된 가격
+     * @param originPrice
+     * @param discountAmount
+     * @return
      */
-    private long calculateAmount(long price, Promotion promotion) {
-        if (promotion.getDiscountType() == DiscountType.PERCENT) {
-            return (long) (price * (promotion.getDiscountValue() / 100.0));
+    public static DiscountResult createDiscountResult(long originPrice, long discountAmount) {
+        if (originPrice <= 0 || discountAmount <= 0) {
+            return new DiscountResult(originPrice, originPrice, 0.0, 0L);
         }
-        return promotion.getDiscountValue(); // FIXED_AMOUNT
+
+        long finalPrice = Math.max(0, originPrice - discountAmount);
+
+        // 할인율 계산 및 소수점 첫째 자리 반올림 (15.56 -> 15.6)
+        double rawRate = ((double) discountAmount / originPrice) * 100;
+        double discountRate = Math.round(rawRate * 10.0) / 10.0;
+
+        return new DiscountResult(originPrice, finalPrice, discountRate, discountAmount);
+    }
+
+    /**
+     * 할인되는 금액 계산
+     *
+     * @param price 원래 숙소의 가격
+     * @param promotion 프로모션
+     * @return 할인되는 금액
+     */
+    public static long calculateAmount(long price, Promotion promotion) {
+        if (promotion.getDiscountType() == DiscountType.PERCENT) {
+            // 할인액 계산시 반올림 처리
+            return Math.round(price * (promotion.getDiscountValue() / 100.0));
+        }
+        // 정액 할인의 경우 원가를 넘지 않도록 제한
+        return Math.min(price, promotion.getDiscountValue()); // FIXED_AMOUNT
+    }
+
+    /**
+     * 할인 금액 평균값 계산
+     *
+     * @param history
+     * @return
+     */
+    public static double calculateAverageDiscount(List<DiscountResult> history) {
+        // 평균 금액 계산
+        OptionalDouble average =
+                history.stream().mapToLong(DiscountResult::getDiscountedPrice).average();
+
+        // 값이 없을 경우를 대비해 기본값 설정
+        return average.orElse(0.0);
     }
 }

--- a/services/inventory-service/src/main/java/com/paystream/inventory/store/entity/Store.java
+++ b/services/inventory-service/src/main/java/com/paystream/inventory/store/entity/Store.java
@@ -30,33 +30,25 @@ public class Store extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String hostId;
 
-    @Column(nullable = false)
     private String name;
 
     private String description;
 
-    @Column(nullable = false)
-    @Embedded
-    private Address address;
+    @Embedded private Address address;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Category category;
 
     // 체크인 시간
-    @Column(nullable = false)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH")
     private LocalTime checkInTime;
 
     // 체크아웃 시간
-    @Column(nullable = false)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH")
     private LocalTime checkOutTime;
 
-    @Column(nullable = false)
     private int basePersonCount;
 
     @Builder.Default private double rating = 0.0;
@@ -67,7 +59,7 @@ public class Store extends BaseEntity {
     @Builder.Default
     @ElementCollection
     @CollectionTable(name = "store_amenities", joinColumns = @JoinColumn(name = "store_id"))
-    @Column(name = "amenity", nullable = false)
+    @Column(name = "amenity")
     @Enumerated(EnumType.STRING)
     private List<Amenities> amenities = new ArrayList<>();
 

--- a/services/inventory-service/src/test/java/com/paystream/inventory/product/service/ProductPriceHistoryServiceTest.java
+++ b/services/inventory-service/src/test/java/com/paystream/inventory/product/service/ProductPriceHistoryServiceTest.java
@@ -87,7 +87,7 @@ class ProductPriceHistoryServiceTest {
         }
         promotionRepository.saveAll(promotions);
 
-        Long productId = 1L;
+        Long productId = savedProduct.getId();
         LocalDate startDate = LocalDate.now();
         LocalDate endDate = LocalDate.now().plusDays(2);
 

--- a/services/inventory-service/src/test/java/com/paystream/inventory/product/service/ProductPriceHistoryServiceTest.java
+++ b/services/inventory-service/src/test/java/com/paystream/inventory/product/service/ProductPriceHistoryServiceTest.java
@@ -1,0 +1,117 @@
+package com.paystream.inventory.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.paystream.inventory.inventory.entity.DailyInventory;
+import com.paystream.inventory.inventory.repository.DailyInventoryRepository;
+import com.paystream.inventory.product.dto.response.ProductPriceHistoryResponse;
+import com.paystream.inventory.product.entity.Product;
+import com.paystream.inventory.product.repository.ProductRepository;
+import com.paystream.inventory.promotion.entity.DiscountType;
+import com.paystream.inventory.promotion.entity.Promotion;
+import com.paystream.inventory.promotion.entity.PromotionStatus;
+import com.paystream.inventory.promotion.entity.TargetType;
+import com.paystream.inventory.promotion.repository.PromotionRepository;
+import com.paystream.inventory.store.entity.Store;
+import com.paystream.inventory.store.repository.StoreRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+class ProductPriceHistoryServiceTest {
+
+    @Autowired private ProductPriceHistoryService productPriceHistoryService;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private PromotionRepository promotionRepository;
+
+    @Autowired private StoreRepository storeRepository;
+
+    @Autowired private DailyInventoryRepository dailyInventoryRepository;
+
+    @DisplayName("해당 숙소의 역대 세일 내역 리스트롤 조회할 수 있다,")
+    @Test
+    void testGetPriceHistoryDetails() {
+        // given
+        Store store = Store.builder().hostId("host-1").name("TEST STORE").build();
+        Store savedStore = storeRepository.save(store);
+
+        Product product =
+                Product.builder()
+                        .store(savedStore)
+                        .name("TEST PRODUCT")
+                        .basePrice(10000)
+                        .baseStock(5)
+                        .build();
+        Product savedProduct = productRepository.save(product);
+
+        List<DailyInventory> inventories = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            DailyInventory inventory =
+                    DailyInventory.builder()
+                            .product(savedProduct)
+                            .date(LocalDate.now().plusDays(i))
+                            .stockAvailable(5)
+                            .build();
+
+            inventories.add(inventory);
+        }
+        dailyInventoryRepository.saveAll(inventories);
+
+        List<Promotion> promotions = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Promotion promotion =
+                    Promotion.builder()
+                            .createUserId("host-1")
+                            .title("TEST PROMOTION")
+                            .targetId(savedProduct.getId())
+                            .targetType(TargetType.PRODUCT)
+                            .discountType(DiscountType.PERCENT)
+                            .discountValue((i + 1) * 10)
+                            .startDate(LocalDate.now().plusDays(i))
+                            .endDate(LocalDate.now().plusDays(i + 1))
+                            .status(PromotionStatus.ACTIVE)
+                            .build();
+            promotions.add(promotion);
+        }
+        promotionRepository.saveAll(promotions);
+
+        Long productId = 1L;
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now().plusDays(2);
+
+        // when
+        List<ProductPriceHistoryResponse> result =
+                productPriceHistoryService.getPriceHistoryDetails(productId, startDate, endDate);
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .extracting(
+                        "startDate", "endDate", "originPrice", "discountedPrice", "discountRate")
+                .containsExactly( // 시작일자 내림차순
+                        Tuple.tuple(
+                                LocalDate.now().plusDays(1),
+                                LocalDate.now().plusDays(2),
+                                (long) product.getBasePrice(),
+                                8000L,
+                                20.0),
+                        Tuple.tuple(
+                                LocalDate.now(),
+                                LocalDate.now().plusDays(1),
+                                (long) product.getBasePrice(),
+                                9000L,
+                                10.0));
+    }
+}

--- a/services/inventory-service/src/test/java/com/paystream/inventory/store/service/StoreFindServiceTest.java
+++ b/services/inventory-service/src/test/java/com/paystream/inventory/store/service/StoreFindServiceTest.java
@@ -295,17 +295,17 @@ class StoreFindServiceTest {
         // A호텔 검증: 10만 -> 8만 (20%)
         StoreResponse resA = findResponseByName(response, "A 호텔");
         assertThat(resA.getProducts().get(0).getPrice().getDiscounted()).isEqualTo(80_000L);
-        assertThat(resA.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(20);
+        assertThat(resA.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(20.0);
 
         // B 리조트 검증: 15만 -> 10만 (33%)
         StoreResponse resB = findResponseByName(response, "B 글램핑");
         assertThat(resB.getProducts().get(0).getPrice().getDiscounted()).isEqualTo(100_000L);
-        assertThat(resB.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(33);
+        assertThat(resB.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(33.3);
 
         // C 펜션 검증: 5만 -> 5만 (0%)
         StoreResponse resC = findResponseByName(response, "C 펜션");
         assertThat(resC.getProducts().get(0).getPrice().getDiscounted()).isEqualTo(50_000L);
-        assertThat(resC.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(0);
+        assertThat(resC.getProducts().get(0).getPrice().getDiscountRate()).isEqualTo(0.0);
     }
 
     @DisplayName("가게 상세 조회시, 가게 할인과 상품 할인 중 혜택이 큰 것이 적용되어 응답된다.")


### PR DESCRIPTION
## 📌 PR 개요
- 숙소에 대한 할인 이력을 조회합니다.

## 🔍 변경 사항
- Store, Product 엔티티 컬럼의 Nullable 어노테이션 제거
- 할인 이력은 날짜로 필터링 할 수 있으며, 화면에서 1개월, 3개월 6개월, 1년으로 조회하는 것이 좋아보입니다.
- 조회는 조회기준일자로 부터 최대 1년 전까지만 조회 가능

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 가게와 숙소, 제고 데이터를 생성한 후 프로모션과 숙소를 연결한다.
2. 연결이 완료되면 API를 통해 조회한다.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 🗣️ 공유 사항
<!-- 팀원에게 공유할 내용을 작성해주세요 -->
-

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #